### PR TITLE
feat: add Google Analytics 4 tracking

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
         "@mdx-js/loader": "^3.1.0",
         "@mdx-js/react": "^3.1.0",
         "@next/mdx": "^15.0.3",
+        "@next/third-parties": "^15.0.3",
         "gray-matter": "^4.0.3",
         "next": "15.0.3",
         "next-mdx-remote": "^5.0.0",
@@ -952,6 +953,19 @@
       ],
       "engines": {
         "node": ">= 10"
+      }
+    },
+    "node_modules/@next/third-parties": {
+      "version": "15.0.3",
+      "resolved": "https://registry.npmjs.org/@next/third-parties/-/third-parties-15.0.3.tgz",
+      "integrity": "sha512-T2NkBXLcgRY0cmE7jb/dSMXNK9D+yv1k+n0uBxwMBS9SEtOhuMvxiUPQRj5x4cFnsei6JECloJg88koMprKw0A==",
+      "license": "MIT",
+      "dependencies": {
+        "third-party-capital": "1.0.20"
+      },
+      "peerDependencies": {
+        "next": "^13.0.0 || ^14.0.0 || ^15.0.0",
+        "react": "^18.2.0 || 19.0.0-rc-66855b96-20241106"
       }
     },
     "node_modules/@nodelib/fs.scandir": {
@@ -7077,6 +7091,12 @@
       "engines": {
         "node": ">=0.8"
       }
+    },
+    "node_modules/third-party-capital": {
+      "version": "1.0.20",
+      "resolved": "https://registry.npmjs.org/third-party-capital/-/third-party-capital-1.0.20.tgz",
+      "integrity": "sha512-oB7yIimd8SuGptespDAZnNkzIz+NWaJCu2RMsbs4Wmp9zSDUM8Nhi3s2OOcqYuv3mN4hitXc8DVx+LyUmbUDiA==",
+      "license": "ISC"
     },
     "node_modules/to-regex-range": {
       "version": "5.0.1",

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "@mdx-js/loader": "^3.1.0",
     "@mdx-js/react": "^3.1.0",
     "@next/mdx": "^15.0.3",
+    "@next/third-parties": "^15.0.3",
     "gray-matter": "^4.0.3",
     "next": "15.0.3",
     "next-mdx-remote": "^5.0.0",

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,5 +1,6 @@
 import localFont from 'next/font/local'
 import Link from 'next/link'
+import { GoogleAnalytics } from '@next/third-parties/google'
 import './globals.css'
 
 const atkinson = localFont({
@@ -95,6 +96,7 @@ export default function RootLayout({
             © {new Date().getFullYear()} Wayne Wen
           </div>
         </footer>
+        <GoogleAnalytics gaId="G-P9BJ1DCTPB" />
       </body>
     </html>
   )


### PR DESCRIPTION
## Summary

**Google Analytics Integration**

This PR adds Google Analytics 4 tracking to the blog using Next.js's official third-party integration package.

## Changes

- Added @next/third-parties package
- Integrated GA4 tracking in root layout
- Configured with measurement ID: G-P9BJ1DCTPB

No additional configuration needed as we're using default event tracking for now.