### PR TITLE
feat(content): add two-leaders-one-second post and reproduction demo

### DIFF
--- a/public/repro/two-leaders-one-second/README.md
+++ b/public/repro/two-leaders-one-second/README.md
@@ -1,0 +1,81 @@
+# Reproducing "Two Leaders, One Second"
+
+A ~150-line controller that reproduces the dual-child outcome described in the blog post, using `controller-runtime`'s standard builder API. No CRDs, no kubebuilder scaffolding.
+
+## Prerequisites
+
+- Go 1.21 or later
+- [kind](https://kind.sigs.k8s.io/) (or any local Kubernetes cluster)
+- `kubectl`
+
+## Setup
+
+```bash
+kind create cluster --name leader-race
+go mod tidy
+```
+
+## Reproduce the bug
+
+Open three terminals.
+
+**Terminal A** (writer A):
+
+```bash
+WRITER_ID=A go run . --force-race
+```
+
+**Terminal B** (writer B):
+
+```bash
+WRITER_ID=B go run . --force-race
+```
+
+**Terminal C** (create the parent):
+
+```bash
+kubectl create configmap demo-parent
+kubectl label cm demo-parent demo=parent
+```
+
+Both writers will log a `Reconcile START`, enter the 10s slow-downstream window simultaneously, and then call `client.Create` at the apiserver next to each other. After ~12 seconds:
+
+```bash
+kubectl get secrets -l demo-child=demo-parent
+```
+
+Expected output: **two** secrets, with different `GenerateName` suffixes.
+
+```
+NAME                       TYPE     DATA   AGE
+demo-parent-child-9j2pk    Opaque   0      3s
+demo-parent-child-pkx4f    Opaque   0      3s
+```
+
+On the next reconcile loop both writers will list the same two children, log the singleton-invariant violation, and stop. This is the same state production saw 29 days in a row.
+
+## What `--force-race` does
+
+1. **Disables leader election** so both writers reconcile concurrently. In production, leader election usually prevents this. But during the brief dual-leader window described in the blog post, the same race occurs naturally for a few hundred milliseconds.
+2. **Adds a 10s sleep** before `client.Create`, modeling a slow downstream call that does not honor `ctx` cancellation. Both writers enter the slow window at the same time and exit at the same time, making the race deterministic.
+
+## See the normal singleton behavior
+
+Drop `--force-race` to run with leader election on. One writer is leader, the other waits as standby. Exactly one child gets created. This is what the operator looks like 99% of the time.
+
+```bash
+go run .       # Terminal A: becomes leader
+go run .       # Terminal B: standby
+```
+
+## The honest caveat
+
+Faithfully reproducing the production *timing* (an in-flight `Create` surviving the graceful drain) requires apiserver-side slowness, typically a validating webhook with `time.Sleep`. That setup adds TLS certs and ~100 lines and is omitted here.
+
+The structural demo is sufficient because the observable outcome is identical to production: two children for one parent. The post explains the production mechanism (lease handoff during in-flight Create); this demo proves the apiserver does not validate that the writer is the lease-holder.
+
+## Clean up
+
+```bash
+kind delete cluster --name leader-race
+```

--- a/public/repro/two-leaders-one-second/go.mod
+++ b/public/repro/two-leaders-one-second/go.mod
@@ -1,0 +1,64 @@
+module leader-race-demo
+
+go 1.22.0
+
+require (
+	k8s.io/api v0.30.1
+	k8s.io/apimachinery v0.30.1
+	k8s.io/client-go v0.30.1
+	sigs.k8s.io/controller-runtime v0.18.4
+)
+
+require (
+	github.com/beorn7/perks v1.0.1 // indirect
+	github.com/cespare/xxhash/v2 v2.2.0 // indirect
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/emicklei/go-restful/v3 v3.11.0 // indirect
+	github.com/evanphx/json-patch/v5 v5.9.0 // indirect
+	github.com/fsnotify/fsnotify v1.7.0 // indirect
+	github.com/go-logr/logr v1.4.1 // indirect
+	github.com/go-openapi/jsonpointer v0.19.6 // indirect
+	github.com/go-openapi/jsonreference v0.20.2 // indirect
+	github.com/go-openapi/swag v0.22.3 // indirect
+	github.com/gogo/protobuf v1.3.2 // indirect
+	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da // indirect
+	github.com/golang/protobuf v1.5.4 // indirect
+	github.com/google/gnostic-models v0.6.8 // indirect
+	github.com/google/go-cmp v0.6.0 // indirect
+	github.com/google/gofuzz v1.2.0 // indirect
+	github.com/google/uuid v1.3.0 // indirect
+	github.com/imdario/mergo v0.3.6 // indirect
+	github.com/josharian/intern v1.0.0 // indirect
+	github.com/json-iterator/go v1.1.12 // indirect
+	github.com/mailru/easyjson v0.7.7 // indirect
+	github.com/matttproud/golang_protobuf_extensions v1.0.4 // indirect
+	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
+	github.com/modern-go/reflect2 v1.0.2 // indirect
+	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
+	github.com/pkg/errors v0.9.1 // indirect
+	github.com/prometheus/client_golang v1.16.0 // indirect
+	github.com/prometheus/client_model v0.4.0 // indirect
+	github.com/prometheus/common v0.44.0 // indirect
+	github.com/prometheus/procfs v0.12.0 // indirect
+	github.com/spf13/pflag v1.0.5 // indirect
+	golang.org/x/exp v0.0.0-20220722155223-a9213eeb770e // indirect
+	golang.org/x/net v0.23.0 // indirect
+	golang.org/x/oauth2 v0.12.0 // indirect
+	golang.org/x/sys v0.18.0 // indirect
+	golang.org/x/term v0.18.0 // indirect
+	golang.org/x/text v0.14.0 // indirect
+	golang.org/x/time v0.3.0 // indirect
+	gomodules.xyz/jsonpatch/v2 v2.4.0 // indirect
+	google.golang.org/appengine v1.6.7 // indirect
+	google.golang.org/protobuf v1.33.0 // indirect
+	gopkg.in/inf.v0 v0.9.1 // indirect
+	gopkg.in/yaml.v2 v2.4.0 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
+	k8s.io/apiextensions-apiserver v0.30.1 // indirect
+	k8s.io/klog/v2 v2.120.1 // indirect
+	k8s.io/kube-openapi v0.0.0-20240228011516-70dd3763d340 // indirect
+	k8s.io/utils v0.0.0-20230726121419-3b25d923346b // indirect
+	sigs.k8s.io/json v0.0.0-20221116044647-bc3834ca7abd // indirect
+	sigs.k8s.io/structured-merge-diff/v4 v4.4.1 // indirect
+	sigs.k8s.io/yaml v1.3.0 // indirect
+)

--- a/public/repro/two-leaders-one-second/main.go
+++ b/public/repro/two-leaders-one-second/main.go
@@ -1,0 +1,208 @@
+// Minimal reproduction of the operator bug described in the post
+// "Two Leaders, One Second."
+//
+// In production, two operator pods briefly contend for the same leader lease
+// during a rolling restart. A worker still inside Reconcile when the lease
+// handoff fires can land a client.Create at the apiserver next to the new
+// leader's own Create. With GenerateName, the apiserver allocates two
+// different suffixes. The singleton invariant breaks.
+//
+// This demo isolates the load-bearing fact (the apiserver does not validate
+// that the writer is the lease-holder) by bypassing leader election. Both
+// processes reconcile the same parent concurrently. Both call client.Create
+// with the same GenerateName base. The apiserver accepts both. Two children
+// are persisted, just like in production.
+//
+// Run (with kind + kubectl on PATH, Go 1.21+):
+//
+//	kind create cluster --name leader-race
+//	go mod tidy
+//
+//	# Terminal A:
+//	WRITER_ID=A go run . --force-race
+//
+//	# Terminal B:
+//	WRITER_ID=B go run . --force-race
+//
+//	# Terminal C:
+//	kubectl create configmap demo-parent
+//	kubectl label cm demo-parent demo=parent
+//
+//	# After ~12 seconds:
+//	kubectl get secrets -l demo-child=demo-parent
+//	# Expected: TWO secrets with different GenerateName suffixes.
+//
+//	# Clean up:
+//	kind delete cluster --name leader-race
+//
+// What --force-race does:
+//
+//  1. Disables leader election so both writers reconcile concurrently.
+//     In production, leader election usually prevents this. But during the
+//     brief dual-leader window (a graceful shutdown abandoning a worker
+//     mid-reconcile, see the post for the mechanism), the same race
+//     manifests for a few hundred milliseconds.
+//
+//  2. Adds a 10s sleep before client.Create, so both writers enter the
+//     create at the same time. This makes the race deterministic.
+//
+// Faithfully reproducing the production timing (in-flight Create surviving
+// the drain) requires apiserver-side slowness, typically a validating
+// webhook. That setup is omitted here for brevity. The structural demo is
+// sufficient because the observable outcome is identical: two children for
+// one parent.
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"log"
+	"os"
+	"os/signal"
+	"syscall"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/builder"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+)
+
+var scheme = runtime.NewScheme()
+
+func init() {
+	utilruntime.Must(clientgoscheme.AddToScheme(scheme))
+}
+
+type reconciler struct {
+	client.Client
+	writerID  string
+	forceRace bool
+}
+
+func (r *reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reconcile.Result, error) {
+	tag := "[" + r.writerID + "] "
+	log.Printf("%sReconcile START parent=%s", tag, req.NamespacedName)
+
+	// List existing children for this parent.
+	var children corev1.SecretList
+	if err := r.List(ctx, &children,
+		client.InNamespace(req.Namespace),
+		client.MatchingLabels{"demo-child": req.Name}); err != nil {
+		return reconcile.Result{}, err
+	}
+	if len(children.Items) >= 1 {
+		log.Printf("%sfound %d existing children, skipping create", tag, len(children.Items))
+		if len(children.Items) > 1 {
+			log.Printf("%s!! singleton invariant violated: %d children for one parent !!",
+				tag, len(children.Items))
+		}
+		return reconcile.Result{}, nil
+	}
+
+	// Fetch the parent so we can owner-ref the child.
+	var parent corev1.ConfigMap
+	if err := r.Get(ctx, req.NamespacedName, &parent); err != nil {
+		return reconcile.Result{}, client.IgnoreNotFound(err)
+	}
+
+	// Optional slow work, modeling a downstream call that ignores ctx cancellation
+	// (a Kafka publish, an S3 upload, a slow gRPC). With force-race, both writers
+	// enter this at the same time and exit at the same time, so both Creates land
+	// next to each other.
+	if r.forceRace {
+		log.Printf("%sslow downstream call starting (10s)...", tag)
+		time.Sleep(10 * time.Second)
+		log.Printf("%sslow downstream call done", tag)
+	}
+
+	// Create the child with GenerateName. The apiserver allocates a random
+	// suffix per Create call, so two concurrent Creates produce two children.
+	child := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			GenerateName: req.Name + "-child-",
+			Namespace:    req.Namespace,
+			Labels: map[string]string{
+				"demo-child": req.Name,
+				"created-by": r.writerID,
+			},
+			OwnerReferences: []metav1.OwnerReference{{
+				APIVersion: "v1",
+				Kind:       "ConfigMap",
+				Name:       parent.Name,
+				UID:        parent.UID,
+				Controller: ptr(true),
+			}},
+		},
+	}
+	if err := r.Create(ctx, child); err != nil {
+		log.Printf("%sCreate FAILED: %v", tag, err)
+		return reconcile.Result{}, err
+	}
+	log.Printf("%sCreate SUCCESS child=%s", tag, child.Name)
+	return reconcile.Result{}, nil
+}
+
+func ptr[T any](v T) *T { return &v }
+
+func main() {
+	writerID := os.Getenv("WRITER_ID")
+	if writerID == "" {
+		writerID = fmt.Sprintf("writer-%d", os.Getpid())
+	}
+	var forceRace bool
+	flag.BoolVar(&forceRace, "force-race", false,
+		"disable leader election and slow the Create so both writers race")
+	flag.Parse()
+
+	cfg, err := ctrl.GetConfig()
+	if err != nil {
+		log.Fatalf("get kubeconfig: %v", err)
+	}
+
+	mgr, err := ctrl.NewManager(cfg, manager.Options{
+		Scheme:                        scheme,
+		LeaderElection:                !forceRace,
+		LeaderElectionID:              "leader-race-demo",
+		LeaderElectionNamespace:       "default",
+		LeaderElectionReleaseOnCancel: true,
+	})
+	if err != nil {
+		log.Fatalf("new manager: %v", err)
+	}
+
+	// Reconcile only ConfigMaps labeled demo=parent.
+	pred := predicate.NewPredicateFuncs(func(obj client.Object) bool {
+		return obj.GetLabels()["demo"] == "parent"
+	})
+
+	if err := builder.ControllerManagedBy(mgr).
+		Named("demo").
+		For(&corev1.ConfigMap{}, builder.WithPredicates(pred)).
+		Owns(&corev1.Secret{}).
+		Complete(&reconciler{
+			Client:    mgr.GetClient(),
+			writerID:  writerID,
+			forceRace: forceRace,
+		}); err != nil {
+		log.Fatalf("build controller: %v", err)
+	}
+
+	ctx, cancel := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer cancel()
+
+	log.Printf("[%s] starting manager (leader-election=%v force-race=%v)",
+		writerID, !forceRace, forceRace)
+	if err := mgr.Start(ctx); err != nil {
+		log.Fatalf("manager.Start: %v", err)
+	}
+	log.Printf("[%s] manager exited", writerID)
+}

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -79,6 +79,30 @@ html {
     /* Link color - Catppuccin Mocha Lavender */
     --link-color: #b4befe;
     --link-color-hover: #cdd6f4;
+
+    /* Mermaid & diagram tokens: Catppuccin Frappé Dark */
+    --mermaid-bg: #1e1e2e;
+    --mermaid-primary: #8caaee;
+    --mermaid-primary-fill: #2a3045;
+    --mermaid-secondary: #ca9ee6;
+    --mermaid-secondary-fill: #3a2e44;
+    --mermaid-tertiary: #f4b8e4;
+    --mermaid-tertiary-fill: #3f2e3b;
+    --mermaid-primary-text: #c6d0f5;
+    --mermaid-secondary-text: #a5adce;
+    --mermaid-line: #737994;
+    --mermaid-node-bg: #232634;
+    --mermaid-node-border: #51576d;
+    --mermaid-note-bg: #2e2b27;
+    --mermaid-note-border: #e5c890;
+    --mermaid-actor-bg: #2a3045;
+    --mermaid-actor-border: #8caaee;
+    --mermaid-error: #e78284;
+    --mermaid-error-fill: #3b2c30;
+    --mermaid-warning: #e5c890;
+    --mermaid-warning-fill: #3b342a;
+    --mermaid-success: #a6d189;
+    --mermaid-success-fill: #2c372a;
   }
 }
 

--- a/src/content/preview/two-leaders-one-second.mdx
+++ b/src/content/preview/two-leaders-one-second.mdx
@@ -1,0 +1,137 @@
+---
+title: 'Two Leaders, One Second'
+date: '2026-05-23'
+tags: ['kubernetes', 'distributed-systems', 'controller-runtime']
+category: 'engineering'
+location: 'Palo Alto, CA'
+---
+
+A routine rolling restart of a controller I work on produced **two children for one parent in the same UTC second**. Our in-memory [expectations](/blog/cloneset-pod-thrashing) layer, the abstraction that normally prevents firing a second `Create` while one is still pending, did not catch it for 29 days: the duplicate `Create` came from a different process. When the next reconcile tried to update the child, it found two and refused. The rollout wedged.
+
+The bug was not in the controller's code. It was in an assumption: that Kubernetes leader election guarantees mutual exclusion. It does not.
+
+<Callout>A worker inside <code>Reconcile()</code> outlasted the 30 second graceful drain. The lease released and the new leader acquired, but the old worker&apos;s in flight <code>client.Create</code> was still on the wire. It landed at the apiserver beside the new leader&apos;s. Two children. One parent.</Callout>
+
+## Why Each Step Was Possible
+
+Three latent conditions held in the controller the whole time. A fourth, recent config change pulled the trigger.
+
+**Latent 1: The Lease is not a fencing token.** Either leader can write to the apiserver and the apiserver accepts. The header of [`client-go/tools/leaderelection/leaderelection.go`](https://github.com/kubernetes/client-go/blob/master/tools/leaderelection/leaderelection.go) says so verbatim: *"this implementation does not guarantee that only one client is acting as a leader (a.k.a. fencing)."*
+
+**Latent 2: The graceful drain is cooperative, not preemptive.** controller-runtime&apos;s `StopAndWait` selects on the worker WaitGroup against a 30 second `shutdownCtx`. If the timeout wins, the WaitGroup is abandoned, the worker inside `Reconcile()` keeps running with its HTTP POST on the wire, and the lease releases via a deferred cleanup a few lines later.
+
+**Latent 3: Managed children carry non-deterministic names. This is the root cause.** Each `Create` allocates a fresh random suffix (via `GenerateName`), so two concurrent Creates produce two different names and no collision at the apiserver. With deterministic names derived from the parent, the second writer would get `409 AlreadyExists` and treat it as a benign requeue. The other two latent conditions open the race window; non-deterministic names are what let the race produce a wedged parent instead of a recoverable error.
+
+**Trigger: `LeaderElectionReleaseOnCancel=true`.** We enabled this recently so the leader proactively writes `holderIdentity = ""` to the Lease on graceful shutdown. The standby then acquires in milliseconds instead of waiting ~15 seconds for the lease to expire. Faster failover is a real feature. It also compressed the new leader&apos;s first reconcile sweep into the same window the old worker&apos;s in-flight `Create` was still being processed on the apiserver. This trigger raised the hit rate from theoretical to every rolling restart.
+
+Remove any one of the three latent conditions and the bug class collapses. Remove the trigger and it falls back to theoretical, where it sat for years.
+
+## Where Every Line Fires
+
+```mermaid
+sequenceDiagram
+    autonumber
+    participant P1 as old leader
+    participant API as kube-apiserver
+    participant P2 as new leader
+    participant CH as managed children
+
+    P1->>API: Create child (HTTP POST in flight)
+    note over P1: drain expires, worker abandoned
+    P1->>API: le.release sets holderIdentity to empty
+    P2->>API: acquire Lease
+    P2->>API: List children by ownerUID
+    API-->>P2: empty
+    P2->>API: Create child (random suffix)
+    API-->>CH: persist child-A
+    P1->>API: stalled Create lands
+    API-->>CH: persist child-B (duplicate)
+    P2->>API: next List by ownerUID
+    API-->>P2: 2 children, parent wedged
+```
+
+## Reproduce
+
+Here is a 150 line controller that reproduces the bug in any kind cluster. `ConfigMap` is the parent, `Secret` is the child, both stock built-in types. Both writers reconcile the same parent concurrently (leader election bypassed); both call `client.Create` with the same `GenerateName` base; the apiserver accepts both.
+
+### The reconciler
+
+```go
+func (r *reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reconcile.Result, error) {
+  var children corev1.SecretList
+  if err := r.List(ctx, &children,
+    client.InNamespace(req.Namespace),
+    client.MatchingLabels{"demo-child": req.Name}); err != nil {
+    return reconcile.Result{}, err
+  }
+  if len(children.Items) >= 1 {
+    return reconcile.Result{}, nil
+  }
+  if r.forceRace {
+    time.Sleep(10 * time.Second) // models a slow downstream call
+  }
+  child := &corev1.Secret{
+    ObjectMeta: metav1.ObjectMeta{
+      GenerateName: req.Name + "-child-",
+      Namespace:    req.Namespace,
+      Labels:       map[string]string{"demo-child": req.Name},
+    },
+  }
+  return reconcile.Result{}, r.Create(ctx, child)
+}
+```
+
+### Run it
+
+```bash
+kind create cluster --name leader-race
+go mod tidy
+
+# Terminal A
+WRITER_ID=A go run . --force-race
+
+# Terminal B
+WRITER_ID=B go run . --force-race
+
+# Terminal C
+kubectl create configmap demo-parent
+kubectl label cm demo-parent demo=parent
+sleep 12
+kubectl get secrets -l demo-child=demo-parent
+```
+
+```
+NAME                       AGE
+demo-parent-child-9j2pk    2s
+demo-parent-child-pkx4f    2s
+```
+
+Two children. One parent. The same state production lived with for 29 days. Reproducing the exact production timing (in-flight `Create` surviving the drain) requires apiserver-side slowness, typically a slow webhook; the structural demo suffices because the outcome is identical.
+
+Full source: [`main.go`](/repro/two-leaders-one-second/main.go), [`go.mod`](/repro/two-leaders-one-second/go.mod), [`README.md`](/repro/two-leaders-one-second/README.md).
+
+## The Fix
+
+### Deterministic names for managed resources
+
+Derive child names from the parent (for example, `<parent.name>-<role>` or `<parent.name>-<n>`) instead of letting `GenerateName` allocate a fresh suffix per `Create`. The apiserver already enforces `(namespace, name)` uniqueness. Two leaders racing now produce one persistent child and one `AlreadyExists`, not two children. (Existing children carry random suffixes and `metadata.name` is immutable, so a one-shot migration job per parent creates the deterministic child and removes the legacy one.)
+
+Once names are deterministic, Server-Side Apply with a `FieldOwner` is a clean follow-up. `Apply` is idempotent at the apiserver and targets a specific `(namespace, name)`, so the race becomes a no-op on the loser and the in-memory expectations layer becomes redundant. (SSA does not help on its own: `Apply` needs a known target name, so it presumes the deterministic-name fix above.)
+
+For defense in depth, add a top-level `ReconciliationTimeout` so no single `Reconcile` outlives the drain. This removes the slow-Reconcile precondition before the architectural fix ships.
+
+Keep `LeaderElectionReleaseOnCancel=true`. The bug is the latents, not the trigger.
+
+## Five Things to Check in Your Own Controller
+
+1. Do any managed child resources carry non-deterministic names (typically via `GenerateName`)? Non-deterministic names plus leader election equal this bug.
+2. Does `Reconcile` call external services without per-call timeouts? The static budget matters, not the average.
+3. Is there a top-level `Reconcile` deadline? controller-runtime imposes none.
+4. Is `LeaderElectionReleaseOnCancel=true`? It compresses handoff from ~15s to ~1s, turning checks 1 through 3 from theoretical into routine.
+5. Is your uniqueness constraint enforced server-side? Expectations live in one process; an admission webhook lives in the apiserver. Only the second one survives controller bugs.
+
+## Hints, Not Fences
+
+The Lease is a hint. The apiserver is the fence. Put your invariants where two leaders cannot disagree.
+
+Non-deterministic names trade that fence for a promise: that the controller&apos;s expectations layer will block the second `Create` before it fires. That promise lives in one process, on a happy day. It does not survive a lease handoff, a partial restart, or any moment two writers think they are the only writer. Use names the apiserver can hold.


### PR DESCRIPTION
## Summary

- Add new draft blog post at `src/content/preview/two-leaders-one-second.mdx` walking through a Kubernetes controller race where a graceful rolling restart produced two children for one parent.
- Add runnable reproduction demo at `public/repro/two-leaders-one-second/` (Go + bash + README) that produces the same dual-child outcome against a local `kind` cluster.
- Add Catppuccin Frappé Dark `--mermaid-*` tokens in `globals.css` to theme the post's Mermaid sequence diagram.

## Details

Post structure (6 H2s after the opening + Callout): *Why Each Step Was Possible* (3 latent conditions + 1 trigger) → *Where Every Line Fires* (Mermaid sequence) → *Reproduce* (Go + bash + output) → *The Fix* (deterministic names, with SSA as a follow-up) → *Five Things to Check* → *Hints, Not Fences* (close).

Reproduction demo uses stock built-in types (`ConfigMap` parent, `Secret` child) and `controller-runtime`'s builder API. No CRDs, no kubebuilder scaffolding. Single Go file, ~150 lines.

```mermaid
flowchart LR
  subgraph existing [Existing blog]
    A[src/content/blog/*.mdx]
    B[src/content/preview/*.mdx]
  end
  subgraph new [This PR]
    C[preview/two-leaders-one-second.mdx]
    D[public/repro/two-leaders-one-second/]
    E[globals.css: mermaid tokens]
  end
  C -.references.-> D
  C -.uses.-> E
```

Risk: low. Post lives under `src/content/preview/` so it is accessible only at `/preview/...`, not surfaced on the blog index. Dfiles live in `public/` and are downloadable from tns are scoped to the existing `@media(prefers-color-scheme: dark)` block and only define new variables.
                                                                                                                                ## ## Testing Done

- [x] Verified the post renders at http://localhost:3000/preview/two-leaders-one-second with the Mermaid sequence and Go syntax highlighting.
- [x] `go build ./...` and `go vet ./...` pass on the demo against `controller-runtime v0.18.4` and `k8s.io/* v0.30.1`.
- [x] Demo `--help` works; reconciler signature matches `controller-runtime` builder API.
- [ ] End-to-end demo against a real kind cluster n