### PR TITLE
feat(site): add Strava social link, remove GT3 photo from About

### DIFF
--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -69,22 +69,6 @@ const AboutPage = () => {
         <br/>
         <figure className="relative">
           <Image
-            src="/images/large/992_gt3_large.jpg"
-            alt="992 GT3"
-            width={1600}
-            height={1068}
-            className="rounded-sm"
-            sizes="(max-width: 768px) calc(100vw - 32px), 640px"
-            quality={100}
-          />
-          <figcaption className="mt-2 text-sm text-zinc-600">
-            992 GT3
-          </figcaption>
-        </figure>
-
-        <br/>
-        <figure className="relative">
-          <Image
             src="/images/large/cervelo_s5_large.jpg"
             alt="Cervélo S5"
             width={1600}

--- a/src/config/blog.ts
+++ b/src/config/blog.ts
@@ -9,6 +9,7 @@ export const blogConfig = {
     github: "initor",
     linkedin: "w3e",
     bluesky: "waynewen.com",
+    strava: "38836222",
   },
   siteUrl: "https://waynewen.com",
   defaultTheme: 'system', // for dark mode settings

--- a/src/config/site.ts
+++ b/src/config/site.ts
@@ -32,10 +32,15 @@ export const siteConfig = {
         show: true,
         priority: 4,
       },
+      strava: {
+        url: `https://www.strava.com/athletes/${blogConfig.author.strava}`,
+        show: true,
+        priority: 5,
+      },
       discord: {
         url: `https://discord.gg/TCNdj3ahPz`,
         show: false,
-        priority: 5,
+        priority: 6,
       },
     },
 


### PR DESCRIPTION
## Summary
Adds a Strava profile link to the landing-page social row and removes the 992 GT3 photo from the About page.

## Details
- New `author.strava` handle in `src/config/blog.ts` feeds a `home.socialLinks` entry in `src/config/site.ts` (`https://www.strava.com/athletes/38836222`, `show: true`, priority 5); the hidden `discord` entry moves from priority 5 to 6 so priorities stay unique.
- The landing social row now renders github / linkedin / twitter / bluesky / strava, all styled identically (lowercase label, `aria-label`, `target="_blank"`, `rel="noopener noreferrer"`).
- The About page removes the 992 GT3 `<figure>` (image plus figcaption) and one `<br/>` separator, leaving four photos: Half Moon Bay, Wall-E, 993 Carrera, Cervelo S5.
- The `992_gt3_large.*` image files remain in `public/images` and are now unreferenced; they were left in intentionally as a possible follow-up cleanup.

## Testing Done
- [x] TypeScript type-check is clean (`tsc` reports no errors).
- [x] Manually verified in `next dev`: the Strava link resolves to `https://www.strava.com/athletes/38836222` with the correct lowercase label and aria attributes, and /about renders exactly four photos with no GT3 references.
- No automated test suite covers these config and page changes.
