### PR TITLE
chore(planning): track post material for the CRD bound writeup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,4 +40,9 @@ yarn-error.log*
 next-env.d.ts
 
 # planning
-.planning/
+# The global core.excludesFile ignores ".planning/" as a directory, and git never descends
+# into an excluded directory. So the directory has to be re-included first, or the exception
+# below is a no-op. Contents stay ignored; only post-material is tracked.
+!.planning/
+.planning/*
+!.planning/post-material/

--- a/.planning/post-material/OUTLINE.md
+++ b/.planning/post-material/OUTLINE.md
@@ -1,0 +1,172 @@
+# Drafting outline
+
+A skeleton to write from. Word budgets are targets, not suggestions: published posts here run 553
+to 1102 words, and this material will bloat past 2500 if left unchecked. Every section carries a
+**must not** list, because the failure mode here is over-explaining, not under-explaining.
+
+The three-act shape (how the investigation started, the root cause, why it was us) and the five
+corrections from the storyline are the same skeleton cut two ways. The corrections distribute
+across the acts as noted per section.
+
+**Total target: about 1050 words**, plus the cold open.
+
+---
+
+## Cold open, no heading, about 80 words
+
+Action, then consequence, then the absurdity. Three sentences, the third one long. Then a single
+bridge sentence for readers who do not write CRDs.
+
+Draft:
+
+> We put a ceiling on a CRD field so it could not hold nonsense. On ARM it worked. On x86 the
+> apiserver began rejecting every write, on the grounds that the value was larger than negative
+> nine quintillion.
+
+Then the bridge. Something to the effect of: if you have ever seen a 64-bit ID come back from a
+JSON API with its last digits wrong, this is the same bug wearing different clothes. Cite Twitter's
+`id_str` and the 53-bit rationale, which is verified. Do **not** cite Discord as having the same
+reason; their stated reason is integer overflow and they never mention 53 bits.
+
+**Must not:** explain what a CRD is. Explain the marker syntax. Say "in this post". Use a heading.
+
+---
+
+## The first suspect, about 180 words
+
+Carries **correction 1**: the reader assumes flaky CI.
+
+Four beats and nothing else. Local tests green, every run. CI red. It read as infrastructure, and
+one of the three jobs genuinely was an unrelated cancellation, which made the wrong story more
+convincing. Then the error message, quoted, doing all the heavy lifting because it is absurd on its
+face: a field declared with the largest possible ceiling, rejecting the value 1 for being too
+large.
+
+Kill the false suspect in a two-word sentence, per house style. Then name the assumption that was
+never written down: **a number written in Go source is the number the apiserver enforces.**
+
+End the section by planting the question the third act will answer. One sentence, something like:
+if a bound this ordinary can invert itself, it should be everywhere, and it is not.
+
+**Must not:** narrate the investigation step by step. Describe CI infrastructure. List which
+platforms exist. Explain bazel, test targets, or job names. This section is four beats, not a
+timeline.
+
+---
+
+## The number on disk, about 260 words
+
+Carries **corrections 2, 3, and 4**. This is the densest section and the one most likely to sprawl.
+
+The marker is ordinary Go. In JSON Schema and OpenAPI, `maximum` is a JSON *number*, and the structs
+modelling the schema hold it as a float64: 53 bits of mantissa against the 63 the value needs. So
+the value is rounded **at generation time, before any YAML is written**, and the committed file
+already reads `maximum: 9223372036854776000`, which is 2^63, one more than MaxInt64. The bound
+escaped the range it was meant to cap.
+
+Then correct the three intuitions in sequence, compactly. Text is the only lossless part of the
+pipeline; 19 characters hold the value perfectly. The two actors never read the same string, and
+both parses are deterministic and correct. And the loss happened when the value entered the float64,
+not when it was printed: the serializer emitted its float64 exactly, and that long decimal is simply
+the shortest one that round-trips 2^63.
+
+**Must not:** include the four-operation breakdown table (parse, serialize, parse, narrow). It is
+the clearest explanation in the material and it is redundant with this section. Fold its
+conclusions in and delete it. Also: no bullet list of the three corrections. They are three
+sentences, not three bullets.
+
+---
+
+## Where the architectures disagree, about 220 words
+
+Carries **correction 5**, and holds the section's punchline.
+
+Validation must compare an int64 field against a float64 bound, so something narrows 2^63 back to
+an int64. It does not fit, and the Go specification declines to define what happens. Quote the spec
+verbatim in the single `<Callout>`, then read it flat, in the manner of "it does exactly what it
+promises, which is less than it looks like". The reading to aim for: the spec is not describing an
+edge case, it is declining to have an opinion, and two CPUs took that as permission to disagree.
+
+ARM saturates to MaxInt64, which is by accident exactly the intended bound. x86 returns the integer
+indefinite value, MinInt64. Show the six-byte amd64 function: a bare conversion instruction and a
+return, with nowhere for a check to live.
+
+Then the punchline, which is the strongest fact in the piece. **The toolchain does guard this path.**
+On an integer field it rejects a non-integral bound. That check cannot catch this, because 2^63 as a
+float64 is perfectly integral. The guard asks whether the value is a whole number when the question
+that mattered was whether it survives the round trip. Someone checked. They checked the wrong
+invariant.
+
+**Must not:** claim this is a codegen bug. The float64 is structural, and the destination field in
+the upstream API type is a float64 pointer. Also: verify the guard's exact wording against your
+pinned version before publishing.
+
+---
+
+## Why almost nobody hits this, about 180 words
+
+Pays off the question planted in act one. This is the most differentiating section in the post and
+the one most writers would omit.
+
+Architecture divergence needs the rounded bound to land **outside** int64, which only happens in the
+top few hundred values of the range. Between 2^53 and 2^63 a bound is silently approximated but
+stays in range, so the ceiling is slightly wrong and nobody notices or cares. Two failure modes,
+only one of them loud.
+
+Which means the catastrophic case is reachable essentially only by writing MaxInt64, and **MaxInt64
+is exactly what a careful person writes when a lint rule says always set a Maximum and the field has
+no real ceiling.** The one value you reach for to mean "no limit" is the one value in the range that
+detonates.
+
+Then the inversion. x86 dominates control planes, so a shipped MaxInt64 bound fails loudly and gets
+fixed. The population at risk is the opposite one: teams who develop and test on ARM, ship a bound
+that works perfectly for them, and meet x86 later. That population is growing.
+
+**Must not:** claim other CRDs are silently broken on ARM clusters. That version of the argument is
+backwards and the material explains why.
+
+---
+
+## The fix, about 130 words
+
+Drop the ceiling and document why, rather than picking a slightly smaller wrong number. State the
+transferable rule once, plainly: any integer bound above 2^53 is silently approximated the moment it
+enters an OpenAPI schema, so the value the apiserver enforces is not the value you wrote.
+
+Note the asymmetry in one sentence: the same "no practical limit" idiom is `2147483647` at 32 bits
+and completely safe, because MaxInt32 round-trips through float64 exactly. A correct habit stops
+being correct when the width changes.
+
+Then the upstream state, briefly: no issue exists in the toolchain, in Kubernetes, or in the
+validation libraries, and the specification layer that would have warned you is silent. If you file
+one before publishing, link it here.
+
+Link the repro on the line before the close, using the GitHub tree URL.
+
+**Close on the compiler.** It is the other bookend to the guard punchline, and it should be the last
+thing the reader sees:
+
+> The compiler knew. It just never got to see the number.
+
+---
+
+## Section-by-section correction map
+
+| Section | Correction carried | Evidence landing here |
+|---|---|---|
+| Cold open | none | the absurd error string |
+| The first suspect | 1, flaky CI | three-platform CI split |
+| The number on disk | 2, 3, 4 | the committed YAML line, the float64 round trip |
+| Where the architectures disagree | 5 | Go spec quote, six-byte assembly, the integral guard |
+| Why almost nobody hits this | none, pays off act one | the threshold table, MaxInt32 contrast |
+| The fix | none | 2^53 rule, upstream absence, compile error |
+
+## Standing constraints while drafting
+
+Zero em dashes. `##` only. Zero bullet lists in the body. No Conclusion or Summary section. One
+`<Callout>`, holding the Go specification quote. One diagram with a `<FigCaption>` stating the
+conclusion rather than describing the picture. Footnote every constant to an upstream source. Hedge
+numbers, never mechanisms.
+
+The material files use bullets, tables, and `###` headings for scannability. The post allows none of
+that. Mine them and rebuild in prose.

--- a/.planning/post-material/REVIEW-fresh-eye.md
+++ b/.planning/post-material/REVIEW-fresh-eye.md
@@ -1,0 +1,186 @@
+# Outside review, written before drafting
+
+An adversarial read of the storyline from a cold reader's position. The material is strong. What
+decides this post's ceiling is not content, it is **ordering, framing, and how much gets cut**.
+
+Read this before drafting, not after.
+
+---
+
+## The biggest risk: the audience ceiling
+
+As currently framed this is "a Kubernetes operator author's CRD gotcha." That readership is small.
+
+The underlying phenomenon is not small: **an int64 silently changes value when it crosses a
+JSON-shaped boundary, and nothing along the way checks.** Vastly more people have been bitten by
+that than have ever written a kubebuilder marker. The familiar version lives in JavaScript, where
+`Number` is a float64 and 64-bit IDs from APIs come back subtly wrong.
+
+**Fix:** shortly after the cold open, one sentence that lowers the barrier for a reader who does
+not know what a CRD is. Something to the effect of: if you have ever seen a 64-bit ID come back
+from a JSON API with its last digits wrong, this is the same bug wearing different clothes. One
+sentence, several times the readership, no loss of precision.
+
+The JavaScript precedent has since been verified. Twitter's `id_str` and the 53-bit rationale are
+confirmed in Twitter's own API docs and safe to cite. Discord is **not** safe to cite as "the same
+reason": they do serialize snowflakes as strings, but the reason they give is preventing integer
+overflow, and they never mention 53 bits. Details and exact wording are in the material file's
+"Upstream state and citations" section. Read it before writing this sentence.
+
+## The strongest idea is buried
+
+The compile-time guardrail beat, that Go **refuses** this conversion as a constant and performs it
+silently at runtime, is the best idea in the material. It currently lands in section four of five.
+
+If it is the thesis, plant it in the cold open and pay it off at the end. Right now it arrives as a
+surprise; it should arrive as a **return**.
+
+## The most shareable line is currently a caveat
+
+"I tried to catch the x86 behavior by cross-compiling an x86 binary on my Mac, and Rosetta gave me
+the ARM answer" is the single most quotable moment in the whole investigation. It sits inside the
+repro's honest-caveat discussion.
+
+Promote it to a beat. It converts "this bug hides" from a claim into a **demonstration performed in
+front of the reader**, with the author getting fooled a second time on the page.
+
+## There are no stakes
+
+The material never says what this cost. A reader reaches the third paragraph and thinks: so what?
+
+Even within the disclosure boundary you can say that it wedged CI, that it read as flaky
+infrastructure the entire time, and that local tests passed on every single run while it was
+happening. Without a cost, a bug story reads as a puzzle rather than an incident.
+
+## The title has a real tension worth deciding deliberately
+
+The house formula favours the first-person admission, which is where `I Capped the Wrong Integer`
+comes from, matching `I Deduped the Wrong Race`.
+
+From a cold reader's position that title is **flat**. It reads as a routine confession and carries
+no hook.
+
+Compare `A Maximum of Negative Nine Quintillion`, which puts the absurdity itself in the title and
+makes a scanning reader stop. Note that `Two Leaders, One Second` works the same way: an impossible
+pairing, not a confession.
+
+This is a genuine fork. Decide it on purpose rather than defaulting.
+
+## Cut ruthlessly
+
+Published posts here run 553 to 1102 words. The material, taken whole, would sprawl past 2500.
+
+**Two competing structures are currently fighting:**
+
+| Structure | Strength |
+|---|---|
+| The two-stage table (rounding, then narrowing) | more precise |
+| The five corrections | more readable |
+
+**Recommendation:** the five corrections carry the spine. Compress the two-stage distinction into a
+single small table inside the reveal section.
+
+**Cut entirely:** the four-operation breakdown (parse, serialize, parse, narrow). It is the
+clearest explanation in the material, and it is redundant with corrections three and four. Fold its
+conclusions into those two beats and delete the rest.
+
+---
+
+## On prevalence, with evidence
+
+A hypothesis worth addressing in the post: that this bug is sitting undetected in other CRDs today.
+Two findings sharpen it, and one of them inverts the obvious version of the argument.
+
+### The dangerous window is far narrower than it looks
+
+Architecture divergence requires the rounded float64 to land **outside** int64's range. Measured:
+
+| Marker value | Rounds to | Exact? | Escapes int64? |
+|---|---|---|---|
+| 2^53 - 1 | 9007199254740991 | yes | no |
+| 5 x 10^18 | 5000000000000000000 | yes | no |
+| 2^62 | 4611686018427387904 | yes | no |
+| MaxInt64 - 2048 | 9223372036854773760 | no | no |
+| MaxInt64 - 512 | 9223372036854774784 | no | no |
+| **MaxInt64** | **9223372036854775808** | no | **yes** |
+
+So there are two distinct failure modes, and only the second is architecture-dependent:
+
+Between 2^53 and roughly 2^63, a bound is silently approximated but stays inside int64, so the
+enforced ceiling is slightly wrong and nobody notices or cares. Only in the **top few hundred values
+of the int64 range** does the rounded bound escape, and only there does the architecture split
+appear.
+
+**This makes the story sharper, not weaker.** The catastrophic case is essentially reachable only by
+writing MaxInt64 itself. And MaxInt64 is exactly what a careful person writes when a lint rule says
+"always set a Maximum" and the field has no real ceiling. **The one value you reach for to mean "no
+limit" is the one value in the entire range that detonates.**
+
+### The idiom is safe at 32 bits and lethal at 64
+
+A survey of every numeric bound in the CRDs of one large monorepo found only small values, plus
+three occurrences of `maximum: 2147483647`. That is MaxInt32, the same "no practical limit" idiom,
+and it is **completely safe**: MaxInt32 is far below 2^53 and round-trips through float64 exactly.
+
+That asymmetry is worth a sentence in the post. The habit is correct for `int32` and carries over
+silently into `int64`, where representability quietly stops holding.
+
+### The prevalence argument, corrected
+
+The intuitive version says: other CRDs carry this bug, hidden because their apiservers run on
+non-x86.
+
+That is backwards. x86 dominates Kubernetes control planes. A CRD shipping a MaxInt64 bound would
+fail **loudly and immediately** on most clusters, so it would be caught and fixed rather than
+lurking. The bug is self-limiting in the dominant environment.
+
+The genuinely at-risk population is the opposite one: **teams who develop and test primarily on
+ARM.** Apple Silicon laptops, ARM CI runners, ARM-based clusters. They would ship a bound that works
+perfectly for them and detonates the first time it meets x86. That is precisely what happened here,
+and that population is growing quickly.
+
+**That is the version of the argument to make in the post**, and it is a better one, because it
+implicates a trend the reader is living through rather than a hypothetical fleet somewhere else.
+
+### The hypothesis is now empirically confirmed, in a wider venue than CRDs
+
+Upstream research settled this. The identical artifact is live in public specs today:
+`openai/openai-openapi` carries `minimum: -9223372036854776000 / maximum: 9223372036854776000` on
+its `seed` field, with **three open issues** about it, one of which diagnoses the cause exactly.
+`weaviate` has an open issue reading "int64 boundary value 9223372036854775807 silently truncated to
+9223372036854776000."
+
+So the answer is yes, this is out there right now. But the venue is broader than CRDs: it is an
+**OpenAPI-wide defect class**, reachable by any toolchain that puts an integer bound through a
+float64. That widening is exactly the audience fix this review opened with, and it now has hard
+citations behind it rather than an appeal to intuition.
+
+## Two findings that should change the post, not just support it
+
+### 1. There is a guard, and it checks the wrong property
+
+`controller-tools` does guard this code path: on an integer-typed field it rejects a **non-integral**
+bound. That check cannot catch this, because 2^63 as a float64 is perfectly integral. The guard asks
+"is this a whole number?" when the question that mattered was "does this survive the round trip?"
+
+This is strictly better than the current framing of "nothing along the path checks." Someone did
+check. They checked the wrong invariant. Combined with the Go compiler beat, the post ends up with
+two guardrails: one asking the wrong question, one asking the right question but unable to reach the
+value. **Restructure the thesis around that pair.**
+
+### 2. Nobody has filed this upstream
+
+No issue exists in controller-tools, kubernetes/kubernetes, apiextensions-apiserver, kube-openapi, or
+go-openapi. The defect is undocumented in the Kubernetes ecosystem.
+
+That is an opportunity, and it changes what this post can be. A post that documents a trap is
+useful. A post that documents a trap **and files the first upstream issue about it**, then links to
+it, is a contribution. Consider doing that before publishing and referencing it in the closing.
+
+---
+
+## One-line summary
+
+The material is more rigorous than most engineering blogging. The two things that decide whether
+this post lands are whether you are willing to cut, and whether the first thirty seconds give a
+non-Kubernetes reader a reason to stay.

--- a/.planning/post-material/START-HERE-drafting-prompt.md
+++ b/.planning/post-material/START-HERE-drafting-prompt.md
@@ -1,0 +1,69 @@
+# Start here: drafting this post
+
+Read this file, then follow it.
+
+## Task
+
+Draft a new engineering blog post from prepared material, plus its runnable reproduction.
+
+## Read first, in this order
+
+0. `.planning/post-material/OUTLINE.md`
+   **The drafting skeleton.** Six sections with word budgets, what each must contain, and a
+   "must not" list per section to stop it bloating. Draft against this. Everything below is
+   supporting evidence for it.
+1. `.planning/post-material/ceiling-that-became-a-floor.md`
+   Source material: thesis, the five reader traps, mechanism, evidence table, runnable
+   reproduction, upstream state and citations, honest caveats, disclosure boundary.
+2. `.planning/post-material/WRITING-DNA.md`
+   Extracted style guide for this blog: frontmatter schema, structure, voice, hard rules.
+3. `.planning/post-material/blog-storyline-ceiling-floor-2026-07-25.html`
+   The storyline: five corrections, section spine, evidence placement. Open it in a browser, or
+   read the HTML directly.
+4. `.planning/post-material/defect-landscape-openapi-int64-2026-07-26.html`
+   The case for the post: the re-derived root cause (a guard exists and checks the wrong
+   property), the silence across three specification layers, the absent upstream issue, and the
+   same artifact live in public specs today. This is what lifts the piece above a personal gotcha.
+5. `.planning/post-material/REVIEW-fresh-eye.md`
+   An outside review of the storyline written before drafting began. It names the biggest risks
+   and what to cut. Read it before writing, not after.
+
+Then read two published posts for tone: `src/content/blog/one-second-29-days.mdx` and
+`src/content/blog/cloneset-pod-thrashing.mdx`.
+
+## Then
+
+- **Confirm title and slug with me before writing prose.** The material recommends title
+  `I Capped the Wrong Integer` and slug `ceiling-that-became-a-floor`, but the review argues for a
+  more arresting title. I want to decide this together.
+- Draft to `src/content/preview/<slug>.mdx`.
+- Build the reproduction at `public/repro/<slug>/` with `go.mod`, `main.go`, `README.md`. The
+  verified program and its measured output are in the material file. Follow the README template in
+  `WRITING-DNA.md`, including a `## The honest caveat` section.
+- **Target about 1050 words for the post body**, allocated per section in `OUTLINE.md`. The
+  material is more than twice that. Cutting is part of the job, and the outline says what to cut.
+
+## Hard constraints, all from WRITING-DNA.md
+
+- Zero em dashes, in any form
+- `##` only. No `#` in the body, no `###`
+- Zero bullet lists in the post body
+- No Conclusion, Summary, or References section. The takeaway is the last sentence
+- Cold open with no heading, thesis inside the first 100 words
+- Structure the post by the **five corrections**, not by the bug's chronology
+
+## Two traps to avoid
+
+**Do not mirror the notes' format.** The material files use bullets, tables, and `###` headings for
+scannability. The post allows none of that. Mine them for content and rebuild in prose.
+
+**Do not reintroduce internal names.** The material is already genericized for public release. No
+employer-internal CRD kinds or field names, no ticket IDs, no PR numbers, no internal CI job names,
+no internal repo paths. The "Scope and disclosure" section in the material spells this out. Use a
+neutral `someGeneration` field on a `Widget` CRD where an example is needed.
+
+## One unverified item
+
+Whether `docker run --platform linux/amd64` reproduces the x86 behavior. Docker was not running
+when the material was prepared, and Rosetta 2 was verified **not** to reproduce it. Either verify
+Docker yourself or write it as unverified in the honest caveat. Do not assert it either way.

--- a/.planning/post-material/WRITING-DNA.md
+++ b/.planning/post-material/WRITING-DNA.md
@@ -1,0 +1,210 @@
+# Writing DNA
+
+Extracted 2026-07-25 from the published engineering posts. Reusable across future posts, not
+specific to any one. Derived from `one-second-29-days.mdx`, `cloneset-pod-thrashing.mdx`,
+`the-weekend-it-stopped-starting-over.mdx`, the `two-leaders-one-second` preview and repro, and
+the zod schema in `src/lib/mdx/schemas.ts`.
+
+## Frontmatter
+
+Enforced by zod in `src/lib/mdx/schemas.ts`. `readingTime` is computed at parse time, never
+authored. `ogImage` exists in the schema and is used by zero content files.
+
+| Field | Type | Required | Convention |
+|---|---|---|---|
+| `title` | string | yes | single quotes, Title Case, no colon |
+| `date` | string | yes | `'YYYY-MM-DD'` |
+| `tags` | string[] | no | exactly 3, lowercase, hyphenated |
+| `category` | string | no | `'engineering'` for technical posts |
+| `description` | string | no | present on bug posts, absent on essays and drafts |
+| `location` | string | no | `'Palo Alto, CA'` |
+
+Follow the newest post's field order:
+
+```
+---
+title: 'I Deduped the Wrong Race'
+date: '2026-05-28'
+description: 'An in-memory guard kept a controller from making duplicate children. It only ever held within one process, until a faster-failover setting briefly ran two.'
+tags: ['kubernetes', 'distributed-systems', 'controller-runtime']
+category: 'engineering'
+location: 'Palo Alto, CA'
+---
+```
+
+The `description` is a two-sentence miniature of the post: setup, then a reversal hinged on
+"until" or a short fix clause.
+
+**Slug is not the title.** `one-second-29-days.mdx` carries the title `I Deduped the Wrong Race`.
+The slug keeps the numeric hook; the title carries the confession.
+
+**Drafts** live at `src/content/preview/<slug>.mdx`; promotion to `src/content/blog/` is a file move.
+
+## Structure
+
+**Cold open.** One to three short paragraphs before the first `##`. No heading, no preamble, no
+roadmap. Thesis inside the first 100 words. The strongest example, in full:
+
+> We turned on one setting to make failover faster. It worked. It also surfaced a duplicate the
+> design had been quietly allowing since the day I wrote it.
+
+Sentence lengths: 8 words, 2 words, 22 words. The entire post is in that block.
+
+**Spine.** Four to six `##` sections, sentence case in the newest post, two to five words each,
+readable as a story when listed alone. The forensic shape, with the reveal about 60% in:
+
+1. the design and its known gap
+2. the first suspect, killed fast
+3. the actual mechanism, with code and a quoted authority
+4. the fix, what it cost, repro link, closing epigram
+
+**The false-suspect beat.** Signature move. State the wrong hypothesis, dismiss it in two words,
+then name the real buried assumption:
+
+> My first guess was a regression: some change had broken the expectation, or let a create slip
+> past it. It hadn't. The expectation was intact, doing exactly what I built it for. In one
+> process, it is airtight. In two, it is nothing.
+>
+> That was the assumption I never wrote down: one process. It lived in the shape of the map.
+
+**Section endings are epigrams**, not transitions: "It worked. For two years, not one duplicate." /
+"It does exactly what it promises, which is less than it looks like." / "Not a coincidence."
+
+**Endings.** No Conclusion, no summary, no call to action. The last line is the sharpest line:
+
+> The bug was one second wide. It just took a month to find something standing on it.
+
+## Voice
+
+**Person.** `We` for team action and naming. `I` for judgment, error, and pride. `You` only in
+essay register.
+
+**Tense.** Past for the incident, present for how the system permanently works. Held strictly
+within a paragraph, then snapped back to past when the incident resumes.
+
+**Rhythm.** Mostly 8 to 25 words, punctuated by 2 to 5 word sentences carrying the beat. Never two
+long sentences in a row without a short one near.
+
+**Mode.** Narrative-forensic, never tutorial. No numbered steps in a post body; step-by-step lives
+in the repro README.
+
+**Reader model.** Assumes Kubernetes fluency and Go literacy. Does not assume the specific
+mechanism, which gets glossed inline as a comma appositive the first time it matters, never a
+parenthetical and never a background paragraph:
+
+> we create it with GenerateName, a fixed prefix and a random suffix the API server assigns
+
+**Flat assertion.** No "I think", "arguably", "perhaps". Hedges attach to numbers, never to
+mechanisms.
+
+## Evidence habits
+
+**Code blocks are excerpts.** Three to fourteen lines, always language-tagged, elision explicit
+(`// ...`), with a comment marking the one line that matters. Sometimes a caret underline:
+
+```go
+if !canInPlaceUpdate && util.IsIntPlusAndMinus(updateOldDiff, updateNewDiff) {
+// ^^^^^^^^^^^^^^^^^    one boolean gate
+```
+
+Always introduced by a sentence ending in a colon.
+
+**No console output in post bodies.** Real command output lives in the repro README, shown as an
+untagged fence under an explicit prose expectation with the surprising quantity in bold.
+
+**Claims trace to an artifact.** Timing constants and library behavior get footnotes linking to
+upstream source files. The strongest claim in a post is not argued, it is quoted from the library's
+own documentation inside a `<Callout>`, then read:
+
+> `<Callout>this implementation does not guarantee that only one client is acting as a leader
+> (a.k.a. fencing).</Callout>`
+>
+> It does exactly what it promises, which is less than it looks like.
+
+**Numbers come with their mechanism.** Never a bare metric: "For a CloneSet with `maxSurge` set to
+5%, exactly 5% of replicas are created and destroyed on every in-place update. Not a coincidence."
+
+**Uncertainty.** Hedge timing and scale ("about 15 seconds", "~150-line", "99% of the time"), never
+mechanism. Own errors flatly. A demo's limits get a dedicated `## The honest caveat` heading
+stating what was skipped, why, and why the demo still proves the claim.
+
+**Tables are rare.** One across all three posts, two columns, backticked identifiers.
+
+**Zero bullet lists in post bodies.** Enumerations are written as sentences.
+
+**Diagrams.** A `mermaid` fence renders as a diagram. The one in use is a `sequenceDiagram` with
+`autonumber` and `Note over` lines carrying the argument, followed by a `<FigCaption>` that states
+the conclusion rather than describing the picture. Self-labeling React visualizers get no caption.
+
+**Inline typography.** Backticks for every real identifier. **Bold** only to coin a term on first
+use. *Italic* for a single contrastive word.
+
+## Titles
+
+Actual: `I Deduped the Wrong Race` / `Two Leaders, One Second` / `CloneSet Pod Thrashing` /
+`The Weekend It Stopped Starting Over`.
+
+Three to five words, Title Case, no colon, no subtitle, no "How to", no gerund, no question mark.
+Four shapes:
+
+1. **First-person past-tense admission.** `I Deduped the Wrong Race`. Concedes the mistake before
+   the post does.
+2. **Two-quantity apposition.** `Two Leaders, One Second`. The impossible pair is the title.
+3. **`The <Time Unit> It <Verb Phrase>`.** Definite article, bounded period, reversal clause.
+4. **`<Component> <Symptom>`** for a plain upstream bug report.
+
+Section headings use the same compression, sentence case per the newest post.
+
+## Hard rules
+
+1. **No em dashes in any form**: `--`, ` -- `, `—`, ` — `. Substitute the comma appositive or the
+   semicolon. This was enforced by an automated gate.
+2. **`##` only.** No `#` in the body, no `###` anywhere.
+3. **Every code fence is language-tagged.** A `mermaid` fence renders as a diagram, never as code.
+4. **Footnote definitions at the very bottom**, `[^n]:` format, each linking to a real upstream file.
+5. **Inline markdown links only.** External links get `target="_blank"` automatically; never
+   hand-write anchor tags.
+6. **`<Callout>` holds one short block of plain text.** It renders as a single `<p>`, so no
+   multi-paragraph content, no lists, no headings inside.
+7. **No images in engineering posts.** The `img` override is a fixed cover-cropped block suited to
+   photo posts. Diagrams are mermaid or React components.
+8. **No bullet lists in post bodies.**
+9. **No Conclusion, Summary, TL;DR, or References sections.** Citations are footnotes; the takeaway
+   is the last sentence.
+10. **Frontmatter values in single quotes**, tags lowercase and hyphenated.
+
+## Repro integration
+
+Layout is `public/repro/<slug>/` with `main.go`, `go.mod`, `README.md`.
+
+**Link to the GitHub tree URL, not the site path.** One sentence, near the end of the closing
+section:
+
+> A runnable version is [here](https://github.com/initor/blog-nextjs/tree/master/public/repro/two-leaders-one-second).
+
+The superseded pattern linked the raw file on the site, which browsers download directly instead of
+rendering. Point at the repo directory so readers see the README and source on GitHub.
+
+**Never inline the whole program.** Inline only the load-bearing block, framed by a sentence that
+sets minimal setup and then narrows: "Reproducing this needs nothing exotic: `ConfigMap` as parent,
+`Secret` as child, no CRDs. The important part is only this:"
+
+**README template**, in order: `# Reproducing "<Post Title>"`, one-paragraph scope stating size and
+what is not needed, `## Prerequisites`, `## Setup`, `## Reproduce the bug` with bolded terminal
+labels, expected output in prose with the surprising quantity bolded then an untagged fence,
+`## What <flag> does`, `## See the normal behavior`, `## The honest caveat`, `## Clean up`. The
+README carries a callback to the post's own hook.
+
+## Checklist
+
+- Cold open, 2 to 3 sentences, action then consequence, thesis within 100 words
+- 4 to 6 `##` sections, sentence case, readable as a spine
+- A discarded hypothesis, killed in a two-word sentence
+- Each new mechanism glossed as a comma appositive on first use
+- One code excerpt per claim, elided, with a comment on the load-bearing line
+- One diagram plus a `<FigCaption>` stating the conclusion
+- One `<Callout>` holding a quoted authority or the pivot aphorism
+- Footnote every constant to upstream source
+- Hedge numbers, never mechanisms
+- Close on an epigram; link the repro in the paragraph before it
+- Zero em dashes, bullets, `###`, images, or Conclusion sections

--- a/.planning/post-material/blog-storyline-ceiling-floor-2026-07-25.html
+++ b/.planning/post-material/blog-storyline-ceiling-floor-2026-07-25.html
@@ -1,0 +1,320 @@
+<!DOCTYPE html>
+<html lang="zh-CN" data-theme="auto" data-anim="off">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>故事线：五次纠正</title>
+<style>
+/* ---------- base ---------- */
+* { box-sizing: border-box; }
+html { scroll-behavior: smooth; }
+body {
+  margin: 0; background: var(--bg-primary); color: var(--text-primary);
+  font-family: var(--font-text); font-size: var(--body-size); line-height: 1.5;
+  -webkit-font-smoothing: antialiased;
+  transition: background-color .3s ease, color .3s ease;
+}
+main { max-width: var(--max-width); margin: 0 auto; padding: 0 24px; }
+h1,h2,h3 { font-family: var(--font-display); line-height: 1.12; margin: 0 0 .4em; }
+
+.hero { min-height: var(--hero-min-h); display: flex; flex-direction: column; justify-content: center; padding: 96px 0 48px; }
+.hero h1 { font-size: var(--hero-title-size); letter-spacing: -.01em; }
+.hero .subtitle { color: var(--text-secondary); font-size: 1.18rem; max-width: 60ch; }
+
+.section { padding: var(--section-pad-y) 0; border-top: 1px solid var(--border); }
+.section > h2 { font-size: var(--section-title-size); }
+.section p { color: var(--text-secondary); max-width: 70ch; }
+
+.card-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(220px,1fr)); gap: 20px; }
+.card { background: var(--card-bg); border: var(--card-border); box-shadow: var(--card-shadow); border-radius: var(--card-radius); padding: var(--card-pad); }
+
+.metric .value { font-family: var(--font-display); font-size: 2.6rem; font-weight: 700; color: var(--accent); letter-spacing: -.02em; }
+.metric .label { color: var(--text-secondary); font-size: .82rem; text-transform: uppercase; letter-spacing: .05em; }
+
+.tbl { width: 100%; border-collapse: collapse; }
+.tbl th { text-align: left; padding: 10px 14px; border-bottom: 2px solid var(--border); font-weight: 600; }
+.tbl td { padding: 10px 14px; border-bottom: 1px solid var(--border); }
+.tbl .yes { color: var(--success); } .tbl .no { color: var(--danger); }
+
+.code { background: var(--code-bg); border: 1px solid var(--border); border-radius: 10px; padding: 16px; overflow:auto;
+  font-family: var(--font-mono); font-size: .86rem; line-height: 1.55; }
+
+.callout { border-left: 3px solid var(--accent); background: var(--bg-secondary); border-radius: 0 10px 10px 0; padding: 16px 20px; margin: 20px 0; }
+.callout.warn { border-color: var(--warning); } .callout.danger { border-color: var(--danger); }
+
+#theme-toggle { position: fixed; top: 18px; right: 18px; z-index: 1000; width: 38px; height: 38px; border-radius: 50%;
+  border: 1px solid var(--border); background: var(--card-bg); color: var(--text-primary); cursor: pointer; display: grid; place-items: center; }
+
+.reveal { opacity: 0; transform: translateY(16px); transition: opacity .6s ease, transform .6s ease; }
+.reveal.visible { opacity: 1; transform: none; }
+[data-anim="off"] .reveal { opacity: 1; transform: none; transition: none; }
+
+@media (max-width: 740px) {
+  :root { --hero-title-size: 32px; --section-pad-y: 44px; }
+  main { padding: 0 18px; }
+}
+@media (prefers-reduced-motion: reduce) { .reveal, body { transition: none; } }
+
+/* ---------- flavor: minimal ---------- */
+:root {
+  --font-display: ui-sans-serif, system-ui, -apple-system, "PingFang SC", "Hiragino Sans GB", "Microsoft YaHei", sans-serif;
+  --font-text:    ui-sans-serif, system-ui, -apple-system, "PingFang SC", "Hiragino Sans GB", "Microsoft YaHei", sans-serif;
+  --font-mono:    ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+
+  --bg-primary:#ffffff; --bg-secondary:#f5f5f7; --bg-tertiary:#e8e8ed;
+  --text-primary:#1d1d1f; --text-secondary:#6e6e73; --text-tertiary:#86868b;
+  --accent:#0a84d6; --accent-hover:#0a74bd; --accent-subtle:rgba(10,132,214,.08);
+  --success:#34a853; --warning:#e8910a; --danger:#e0392f;
+  --border:rgba(0,0,0,.08); --card-bg:#ffffff; --card-shadow:none; --code-bg:#f5f5f7;
+
+  --max-width:720px; --section-pad-y:52px; --hero-min-h:auto;
+  --hero-title-size:34px; --section-title-size:22px; --body-size:17px;
+  --card-radius:8px; --card-pad:20px; --card-border:1px solid var(--border);
+}
+[data-theme="dark"] {
+  --bg-primary:#000000; --bg-secondary:#1c1c1e; --bg-tertiary:#2c2c2e;
+  --text-primary:#f5f5f7; --text-secondary:#a1a1a6; --text-tertiary:#86868b;
+  --accent:#2997ff; --accent-hover:#4aa9ff; --accent-subtle:rgba(41,151,255,.14);
+  --success:#30d158; --warning:#ffd60a; --danger:#ff453a;
+  --border:rgba(255,255,255,.10); --card-bg:#1c1c1e; --card-shadow:none; --code-bg:#1c1c1e;
+}
+.hero { min-height: auto; padding: 64px 0 24px; }
+.hero .subtitle { font-size: 1.05rem; }
+.metric .value { font-size: 2rem; }
+.section > h2 { letter-spacing: -.005em; }
+
+/* ---------- page-specific (tokens only) ---------- */
+.beat { border: 1px solid var(--border); border-radius: var(--card-radius); padding: 18px 20px; margin: 16px 0; }
+.beat .head { display: flex; align-items: baseline; gap: 10px; margin-bottom: 12px; }
+.beat .n { font-family: var(--font-mono); font-size: .72rem; color: var(--text-tertiary); letter-spacing: .08em; }
+.beat h3 { font-size: 1rem; margin: 0; }
+.pair { display: grid; grid-template-columns: 1fr 1fr; gap: 0; border: 1px solid var(--border); border-radius: 6px; overflow: hidden; }
+.pair > div { padding: 12px 14px; }
+.pair .w { background: var(--bg-secondary); border-right: 1px solid var(--border); }
+.pair .lab { font-size: .74rem; letter-spacing: .04em; margin-bottom: 5px; }
+.pair .w .lab { color: var(--danger); }
+.pair .r .lab { color: var(--success); }
+.pair .txt { font-size: .9rem; color: var(--text-primary); line-height: 1.45; }
+.role { margin-top: 11px; font-size: .86rem; color: var(--text-secondary); }
+.role b { color: var(--text-primary); font-weight: 600; }
+.fig { margin: 26px 0 8px; }
+.fig svg { width: 100%; height: auto; display: block; }
+.figcap { color: var(--text-tertiary); font-size: .84rem; margin-top: 10px; }
+.spine { list-style: none; margin: 20px 0 0; padding: 0; counter-reset: s; }
+.spine li { position: relative; padding: 0 0 18px 30px; border-left: 1px solid var(--border); }
+.spine li:last-child { border-left-color: transparent; padding-bottom: 0; }
+.spine li::before { counter-increment: s; content: counter(s); position: absolute; left: -11px; top: 0;
+  width: 21px; height: 21px; border-radius: 50%; background: var(--bg-primary); border: 1px solid var(--border);
+  font-size: .7rem; display: grid; place-items: center; color: var(--text-tertiary); font-family: var(--font-mono); }
+.spine h4 { margin: 0 0 4px; font-size: .97rem; font-family: var(--font-display); }
+.spine p { margin: 0; font-size: .89rem; }
+.mono { font-family: var(--font-mono); font-size: .88em; }
+.lede { font-size: 1.06rem; color: var(--text-primary); max-width: 62ch; }
+@media (max-width: 620px) { .pair { grid-template-columns: 1fr; } .pair .w { border-right: none; border-bottom: 1px solid var(--border); } }
+</style>
+</head>
+<body>
+<button id="theme-toggle" aria-label="切换配色"></button>
+<main>
+
+<header class="hero">
+  <h1>故事线：五次纠正</h1>
+  <p class="subtitle">这篇 post 不是按时间顺序讲一个 bug，而是按读者认知的顺序拆掉五个错误直觉。每拆一个，读者就被往「类型」推近一步。</p>
+</header>
+
+<section class="section">
+  <h2>论点</h2>
+  <div class="callout">
+    <p style="margin:0;color:var(--text-primary);font-size:1.04rem">这个 bug 的每一步都由一个<strong>行为正确</strong>的组件完成，跨越了三个进程、两种 CPU 架构和一次 git 提交。发现它的地方和造成它的地方，中间隔着一个<strong>持久化边界</strong>。真正难的不是路径长，而是<strong>沿途没有任何一处是坏的</strong>。缺陷住在两个类型系统交接的缝里，而那道缝上没有任何人设检查。</p>
+  </div>
+  <p>推论：这个 bug 无法用二分定位，因为不存在一个「坏的提交」。也无法用 debugger 抓，因为有一半的执行躺在 git 里。</p>
+</section>
+
+<section class="section">
+  <h2>五次纠正</h2>
+  <p class="lede">这五个误读不是假想的。它们是在向一个已经理解这套系统的人口头解释时，按这个顺序真实出现的。每一个都是聪明人会走的弯路。</p>
+
+  <div class="beat">
+    <div class="head"><span class="n">BEAT 01</span><h3>「CI 抖了」</h3></div>
+    <div class="pair">
+      <div class="w"><div class="lab">读者此刻相信</div><div class="txt">同一个 commit 一会儿过一会儿不过，那就是基础设施问题。</div></div>
+      <div class="r"><div class="lab">真相</div><div class="txt">一个平台是真的在因为真实原因失败。恰好另一个 job 是无关的取消，让错误判断显得更可信。</div></div>
+    </div>
+    <div class="role"><b>叙事作用</b>：房子的招牌动作，先立一个假嫌疑人，两个字杀掉。这也是作者当时真实走过的弯路，写进去读者才会信任后面的推理。</div>
+  </div>
+
+  <div class="beat">
+    <div class="head"><span class="n">BEAT 02</span><h3>「YAML 是文本，所以丢精度」</h3></div>
+    <div class="pair">
+      <div class="w"><div class="lab">读者此刻相信</div><div class="txt">序列化成文本的过程是有损的。</div></div>
+      <div class="r"><div class="lab">真相</div><div class="txt">文本是整条链路里唯一不丢精度的部分。19 个字符把这个值存得好好的。</div></div>
+    </div>
+    <div class="role"><b>叙事作用</b>：第一次把读者的注意力从「文件格式」上撬开。</div>
+  </div>
+
+  <div class="beat">
+    <div class="head"><span class="n">BEAT 03</span><h3>「两个解析器读同一个字符串，结果不同」</h3></div>
+    <div class="pair">
+      <div class="w"><div class="lab">读者此刻相信</div><div class="txt">codegen 和 apiserver 对同一份输入产生了分歧。</div></div>
+      <div class="r"><div class="lab">真相</div><div class="txt">它们从来没读过同一个字符串。codegen 读 <span class="mono">…807</span>，apiserver 读 <span class="mono">…000</span>。两次解析都是确定性的，而且都是对的。</div></div>
+    </div>
+    <div class="role"><b>叙事作用</b>：<b>最有价值的一拍。</b>纠正它，读者才会去看数据模型而不是文件格式。两串都是 19 位数字，长度一样，所以 diff 里看不出来，这个细节值得点出来。</div>
+  </div>
+
+  <div class="beat">
+    <div class="head"><span class="n">BEAT 04</span><h3>「精度是序列化的时候丢的」</h3></div>
+    <div class="pair">
+      <div class="w"><div class="lab">读者此刻相信</div><div class="txt">写出去的那一刻被四舍五入了。</div></div>
+      <div class="r"><div class="lab">真相</div><div class="txt">值在<strong>进入 float64 的那一刻</strong>就已经没了。序列化器把手上的 float64 打印得完全正确，<span class="mono">9223372036854776000</span> 正是能唯一还原回 2<sup>63</sup> 的最短十进制写法。</div></div>
+    </div>
+    <div class="role"><b>叙事作用</b>：与 BEAT 03 并列的核心。推论很实用：<b>去修序列化器什么也修不好</b>，到那一步原始数字已不可恢复。</div>
+  </div>
+
+  <div class="beat">
+    <div class="head"><span class="n">BEAT 05</span><h3>「这是 x86 的问题」</h3></div>
+    <div class="pair">
+      <div class="w"><div class="lab">读者此刻相信</div><div class="txt">架构差异导致了这个 bug。</div></div>
+      <div class="r"><div class="lab">真相</div><div class="txt">架构只决定可见性。值在每一台机器上都已经是错的。ARM 之所以正常，是它的饱和行为<strong>恰好把损坏又还原了回去</strong>，一个未定义行为抵消了另一个。</div></div>
+    </div>
+    <div class="role"><b>叙事作用</b>：收口。把「级联后果」和「根因」彻底分开，读者才不会带着错误结论离开。</div>
+  </div>
+</section>
+
+<section class="section">
+  <h2>五个误读指向同一个方向</h2>
+  <div class="fig">
+    <svg viewBox="0 0 700 210" role="img" aria-label="五个误读都把注意力引向文本与解析，而真正的问题在类型">
+      <defs>
+        <marker id="a2" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+          <path d="M0,0 L10,5 L0,10 z" fill="var(--text-tertiary)"/>
+        </marker>
+        <marker id="a3" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+          <path d="M0,0 L10,5 L0,10 z" fill="var(--accent)"/>
+        </marker>
+      </defs>
+      <g font-family="var(--font-text)" font-size="12.5">
+        <text x="14" y="26" fill="var(--text-tertiary)" font-size="11.5">误读</text>
+        <rect x="8" y="36" width="150" height="26" rx="6" fill="var(--bg-secondary)" stroke="var(--border)"/>
+        <text x="83" y="53" text-anchor="middle" fill="var(--text-secondary)">02　文本有损</text>
+        <rect x="8" y="70" width="150" height="26" rx="6" fill="var(--bg-secondary)" stroke="var(--border)"/>
+        <text x="83" y="87" text-anchor="middle" fill="var(--text-secondary)">03　两个解析器</text>
+        <rect x="8" y="104" width="150" height="26" rx="6" fill="var(--bg-secondary)" stroke="var(--border)"/>
+        <text x="83" y="121" text-anchor="middle" fill="var(--text-secondary)">04　序列化丢的</text>
+
+        <path d="M158,49 Q214,49 214,83 L246,83" fill="none" stroke="var(--text-tertiary)" stroke-width="1.2" marker-end="url(#a2)"/>
+        <path d="M158,83 L246,83" fill="none" stroke="var(--text-tertiary)" stroke-width="1.2" marker-end="url(#a2)"/>
+        <path d="M158,117 Q214,117 214,83 L246,83" fill="none" stroke="var(--text-tertiary)" stroke-width="1.2" marker-end="url(#a2)"/>
+
+        <rect x="250" y="62" width="176" height="42" rx="8" fill="var(--bg-secondary)" stroke="var(--danger)"/>
+        <text x="338" y="80" text-anchor="middle" fill="var(--text-primary)">注意力被引向</text>
+        <text x="338" y="97" text-anchor="middle" fill="var(--danger)" font-size="13">文本 · 解析 · 文件格式</text>
+
+        <path d="M338,104 L338,150" fill="none" stroke="var(--accent)" stroke-width="1.4" stroke-dasharray="4 3" marker-end="url(#a3)"/>
+        <text x="352" y="132" fill="var(--accent)" font-size="11.5">post 要把读者拉回来</text>
+
+        <rect x="250" y="156" width="176" height="42" rx="8" fill="none" stroke="var(--accent)"/>
+        <text x="338" y="174" text-anchor="middle" fill="var(--text-primary)">真正的问题在</text>
+        <text x="338" y="191" text-anchor="middle" fill="var(--accent)" font-size="13">类型 · float64 的 53 位</text>
+
+        <rect x="452" y="52" width="240" height="62" rx="8" fill="var(--bg-secondary)" stroke="var(--border)"/>
+        <text x="466" y="72" fill="var(--text-secondary)" font-size="11.5">这就是结构的依据：</text>
+        <text x="466" y="90" fill="var(--text-secondary)" font-size="11.5">按认知顺序写，不按时间顺序，</text>
+        <text x="466" y="107" fill="var(--text-secondary)" font-size="11.5">每一节拆掉一个直觉。</text>
+      </g>
+    </svg>
+  </div>
+  <p class="figcap">三个误读的方向完全一致，都把人推向文件格式。这不是巧合，而是「YAML 里有个数字看起来不对」这个现场本身在误导。整篇 post 的结构任务，就是反复把读者从文本拉回类型。</p>
+</section>
+
+<section class="section">
+  <h2>章节骨架</h2>
+  <p>五节，句子式小标题，单独列出来能读成一条故事线。对照房子里最新一篇的写法。</p>
+  <ol class="spine">
+    <li><h4>A bound that looked harmless</h4><p>marker 本身，以及那条催生它的、本身合理的 lint 规则。冷开场落在这一节之前，不带标题。</p></li>
+    <li><h4>The first suspect</h4><p>假嫌疑人：基础设施抖动。两个字杀掉，然后点名那个从没写下来的假设：<i>源码里写的数字，就是 apiserver 执行的数字</i>。</p></li>
+    <li><h4>The number on disk</h4><p>第一阶段，四舍五入，与架构无关。BEAT 02 到 04 都在这里拆。提交进 git 的那行 YAML 是本节的实证。</p></li>
+    <li><h4>Where the architectures disagree</h4><p>第二阶段，窄化转换。Go 规范原文进 <span class="mono">&lt;Callout&gt;</span>，六字节汇编收尾。BEAT 05 在这里。</p></li>
+    <li><h4>The fix</h4><p>去掉上限，2<sup>53</sup> 规则，repro 链接，最后一句格言。不写 Conclusion。</p></li>
+  </ol>
+  <div class="callout">
+    <p style="margin:0;color:var(--text-primary)">标题建议 <strong>I Capped the Wrong Integer</strong>（第一人称认错句式，对齐最新一篇），slug 保留数字钩子 <span class="mono">ceiling-that-became-a-floor</span>。</p>
+  </div>
+</section>
+
+<section class="section">
+  <h2>证据落点</h2>
+  <p>每条都在本次调查中实证过，按上面的节次分配。</p>
+  <table class="tbl" style="margin-top:18px">
+    <thead><tr><th>证据</th><th>落在</th></tr></thead>
+    <tbody>
+      <tr><td>提交进 git 的那行 <span class="mono">maximum: 9223372036854776000</span></td><td>第 3 节</td></tr>
+      <tr><td>Go 程序输出：float64 往返后变成 2<sup>63</sup></td><td>第 3 节</td></tr>
+      <tr><td>Go 规范「结果值由实现决定」原文</td><td>第 4 节，<span class="mono">&lt;Callout&gt;</span></td></tr>
+      <tr><td>amd64 六字节函数 <span class="mono">CVTTSD2SQ</span> + <span class="mono">RET</span></td><td>第 4 节</td></tr>
+      <tr><td>x86 报错串 <span class="mono">-9223372036854775808</span></td><td>第 4 节，或提到冷开场</td></tr>
+      <tr><td>常量转换的编译错误</td><td>第 4 或 5 节，作为论点句</td></tr>
+      <tr><td>Rosetta 2 返回 ARM 答案</td><td>第 4 节末尾，或 repro README 的诚实边界</td></tr>
+      <tr><td>三平台 CI 结果对照</td><td>第 2 节，支撑假嫌疑人</td></tr>
+    </tbody>
+  </table>
+  <div class="callout warn">
+    <p style="margin:0;color:var(--text-primary)">尚未验证：Docker <span class="mono">--platform linux/amd64</span> 能否复现。当时 Docker 没运行。写进 repro 的诚实边界，别当成已知结论。</p>
+  </div>
+</section>
+
+<section class="section">
+  <h2>房子的规矩</h2>
+  <table class="tbl" style="margin-top:6px">
+    <thead><tr><th>硬约束</th><th>说明</th></tr></thead>
+    <tbody>
+      <tr><td>零 em dash</td><td>任何形式都不行，用逗号同位语或分号替代</td></tr>
+      <tr><td>只用 <span class="mono">##</span></td><td>正文无 <span class="mono">#</span>，无 <span class="mono">###</span></td></tr>
+      <tr><td>正文零 bullet list</td><td>枚举写成句子</td></tr>
+      <tr><td>无 Conclusion / Summary 小节</td><td>结论就是最后一句</td></tr>
+      <tr><td>冷开场</td><td>无标题，2 到 3 句，100 字内亮论点</td></tr>
+      <tr><td>一个 <span class="mono">&lt;Callout&gt;</span></td><td>放权威原文，随后跟一句平直的解读</td></tr>
+      <tr><td>一张图 + <span class="mono">&lt;FigCaption&gt;</span></td><td>图注写结论，不描述画面</td></tr>
+      <tr><td>repro 链接</td><td>指向 GitHub tree 目录，不是站点上的 <span class="mono">main.go</span></td></tr>
+      <tr><td>脚注</td><td>常量一律注到上游源文件，放正文最末</td></tr>
+    </tbody>
+  </table>
+  <div class="callout danger">
+    <p style="margin:0;color:var(--text-primary)"><strong>素材文件本身用了 bullet 和表格，那是为了速查。post 一个都不能用。</strong>不要把笔记的形态当成结构模板。</p>
+  </div>
+</section>
+
+<section class="section">
+  <h2>不写什么</h2>
+  <p>技术内容全部可公开，它是 JSON Schema、OpenAPI、Go 和 CPU 指令语义的性质，不涉及任何专有信息。但来源工作是内部的。</p>
+  <p style="color:var(--text-primary)">不要出现：内部 CRD 类型名或字段名、这个字段所属的功能或控制器、内部 PR 编号、内部 ticket ID、内部 CI job 或镜像名、内部仓库路径、内部编码规范文档。需要背景时就说「我维护的一个 Kubernetes 控制器」，字段用中性的 <span class="mono">someGeneration</span>。</p>
+  <p>唯一值得泛化而不是删掉的，是那条「数值字段要同时写 Minimum 和 Maximum」的规范。把它描述成一条常见且合理的 lint 规则，不要指向具体文档。它是全文最后一层张力：<strong>一条好规则可以是直接诱因</strong>。</p>
+</section>
+
+</main>
+<script>
+const root = document.documentElement;
+const saved = localStorage.getItem('paint-theme');
+if (saved) root.dataset.theme = saved;
+if (root.dataset.theme === 'auto')
+  root.dataset.theme = matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+const SUN = '<svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="4"/><path d="M12 2v2M12 20v2M4.9 4.9l1.4 1.4M17.7 17.7l1.4 1.4M2 12h2M20 12h2M4.9 19.1l1.4-1.4M17.7 6.3l1.4-1.4"/></svg>';
+const MOON = '<svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M21 12.8A9 9 0 1111.2 3 7 7 0 0021 12.8z"/></svg>';
+const btn = document.getElementById('theme-toggle');
+const paintIcon = () => btn.innerHTML = root.dataset.theme === 'dark' ? SUN : MOON;
+paintIcon();
+btn.addEventListener('click', () => {
+  root.dataset.theme = root.dataset.theme === 'dark' ? 'light' : 'dark';
+  localStorage.setItem('paint-theme', root.dataset.theme);
+  paintIcon();
+});
+if (root.dataset.anim !== 'off') {
+  const io = new IntersectionObserver((es) => es.forEach(e => {
+    if (e.isIntersecting) { e.target.classList.add('visible'); io.unobserve(e.target); }
+  }), { threshold: .12 });
+  document.querySelectorAll('.reveal').forEach(el => io.observe(el));
+} else {
+  document.querySelectorAll('.reveal').forEach(el => el.classList.add('visible'));
+}
+</script>
+</body>
+</html>

--- a/.planning/post-material/ceiling-that-became-a-floor.md
+++ b/.planning/post-material/ceiling-that-became-a-floor.md
@@ -1,0 +1,574 @@
+# Post material: the CRD bound that inverted
+
+Captured 2026-07-25 from a debugging session in a different repo. Everything below was verified
+in that session; the "Verified how" column says by what means. This file is source material for a
+post, not a draft. Write the post from it, do not paste it.
+
+## Working titles
+
+See `WRITING-DNA.md` in this directory for the full formula. Titles run three to five words, Title
+Case, no colon, and come in four shapes. Shape-matched candidates:
+
+**Shape 1, first-person admission** (the newest post's mode, `I Deduped the Wrong Race`):
+- **I Capped the Wrong Integer** (recommended)
+- I Set a Maximum and Got a Minimum
+
+**Shape 2, two-quantity apposition** (`Two Leaders, One Second`):
+- Two Architectures, One Bound
+- One Marker, Two Answers
+
+**Shape 4, component plus symptom** (`CloneSet Pod Thrashing`):
+- CRD Maximum Inversion
+
+Recommended pairing, following the house habit of a slug that keeps the numeric hook while the
+title carries the confession (slug `one-second-29-days` under title `I Deduped the Wrong Race`):
+
+- title: `I Capped the Wrong Integer`
+- slug: `ceiling-that-became-a-floor`
+
+Draft frontmatter `description`, in the house two-sentence shape (setup, then reversal on "until"):
+
+> A CRD field was marked with the largest integer a bound can hold. It validated correctly on ARM
+> and rejected every write on x86, until the generated schema turned out to disagree with itself.
+
+
+## The one-sentence version
+
+A Kubernetes CRD field marked with the largest possible integer ceiling was rejected on x86 and
+accepted on ARM, because the ceiling stopped being a ceiling somewhere between the Go source and
+the apiserver.
+
+## Why it is worth a post
+
+Three things make this more than a war story:
+
+1. The failure is **architecture-dependent**, which almost nothing in a Go/Kubernetes stack is.
+2. Local tests on Apple Silicon pass 100% of the time. The bug is **structurally invisible** on the
+   machine where the code is written.
+3. Go has a **compile-time guardrail for exactly this mistake**, and it cannot fire, because the
+   value arrives through a YAML file at runtime. The language tried to help and was routed around.
+4. Trying to reproduce the x86 behavior on an Apple Silicon machine by cross-compiling an x86
+   binary **also fails to show it**: Rosetta 2 returns the ARM answer. The bug hides on ARM, and it
+   keeps hiding when you emulate x86 on ARM to hunt for it.
+
+Point 3 is the strongest beat and is probably the thesis. Point 4 is the best late-post turn.
+
+---
+
+## Upstream state and citations
+
+Researched 2026-07-25 with sources checked. Treat the negative findings as findings.
+
+### There is a guard, and it checks the wrong property
+
+This is the sharpest fact in the whole investigation and it upgrades the thesis.
+
+`controller-tools` does not blindly accept the marker. In `pkg/crd/markers/validation.go` the
+`Maximum` and `Minimum` markers are declared as `type Maximum float64` / `type Minimum float64`, and
+`ApplyToSchema` carries a guard along the lines of `if schema.Type == Integer && !isIntegral(value)`,
+which rejects a non-integral bound on an integer field.
+
+**That guard cannot catch this.** 2^63 as a float64 *is* integral. The check asks "is this a whole
+number?" when the question that mattered was "does this value survive the round trip?" So MaxInt64
+passes review and sails straight through.
+
+So the story is not "nobody checked." It is **"someone checked, and checked the wrong invariant."**
+Pair that with the Go compiler beat and the post has two guardrails: one that asks the wrong
+question, and one that asks the right question but cannot reach the value.
+
+Note also that the float64 is **structural, not a controller-gen mistake**. The destination field is
+`Maximum *float64` in the upstream Kubernetes API type (`apiextensions/v1/types_jsonschema.go`).
+controller-gen has nowhere else to put the number. Do not write this as a controller-gen bug.
+
+### Nobody has filed this upstream
+
+Searched `kubernetes-sigs/controller-tools`, `kubernetes/kubernetes`,
+`kubernetes/apiextensions-apiserver`, `kube-openapi`, and `go-openapi/validate` for precision,
+rounding, int64, float64, and the literal `9223372036854775807`. **No issue exists on any of them.**
+
+The nearest historical relative is k/k #30213 (closed, 2017), where a large number in a
+ThirdPartyResource came back as `1.000000009e+09`. Same float64 root cause but about **instance
+data**, not **schema bounds**. Do not cite it as the same bug.
+
+This is an opportunity worth naming in the post: the defect is undocumented upstream, so the post
+can be accompanied by filing the first issue.
+
+### The same artifact is live in the wild right now
+
+This is the empirical answer to "does this exist in other people's specs today." Yes, and the
+number is character-for-character identical.
+
+| Project | Issue | State | What it says |
+|---|---|---|---|
+| openai/openai-openapi | #360, #464, #549 | all open | `minimum: -9223372036854776000 / maximum: 9223372036854776000` on the `seed` field. #464 diagnoses it exactly: something in the YAML generation pipeline treats a large integer as floating point |
+| weaviate | #11735 | open | "int64 boundary value 9223372036854775807 silently truncated to 9223372036854776000" |
+
+Caveat to respect: the same 2^63 bounds also appear inside CRD-derived JSON schemas in
+`akuity/kargo` and `datreeio/CRDs-catalog`, but the source CRD in kargo has no `maximum` at all.
+Those bounds are injected by a downstream CRD-to-JSON-Schema converter, not by controller-gen. Same
+defect class, different producer. Do not present them as controller-gen output.
+
+### The canonical Kubernetes warning exists, in an unexpected place
+
+The Kubernetes API Conventions document, "Primitive types" section, states that all numbers are
+converted to float64 by JavaScript, that **`int64` fields must be bounds-checked to be within
+`-(2^53) < x < (2^53)`**, and that values exceeding that should be serialized as strings.
+
+Cite this carefully. That rule governs **Go API field design and serialization**. It says nothing
+literally about OpenAPI `maximum`/`minimum` keywords or about kubebuilder markers. Using it for
+schema-bound precision is an extrapolation, a well-supported one, but the post should say so rather
+than imply the docs already cover this case.
+
+Negative findings worth a sentence: the CRD documentation's validation sections, the api-concepts
+page, and the kubebuilder markers reference contain **no** precision warning at all. The kubebuilder
+book does not even document that `Minimum`/`Maximum` take a float64; the argument-type cell renders
+empty for them while neighbours like `MinItems` render `int`.
+
+### Specification text
+
+- **RFC 8259 section 6 (JSON)** is the strongest citation: integers in
+  `[-(2^53)+1, (2^53)-1]` are "interoperable in the sense that implementations will agree exactly
+  on their numeric values," and implementations should expect no more precision or range than IEEE
+  754 binary64.
+- **JSON Schema 2020-12 section 6.2.2** says the value of `maximum` MUST be a number, not an
+  integer, and section 4.2 explicitly declines to bound precision.
+- **OpenAPI 3.0.3** defines `int64` as "signed 64 bits (a.k.a long)" and says **nothing** about
+  precision limits or IEEE 754. That silence is a real gap in the spec and is worth naming.
+
+### The JavaScript parallel, verified
+
+**Twitter: verified, safe to cite.** `id_str` existed alongside `id`, and Twitter's own API docs
+give the 53-bit rationale across multiple doc eras, including the current developer docs ("In
+JavaScript, integers are limited to 53 bits") and the 2012 snowflake-era page ("some programming
+languages such as Javascript cannot support numbers with >53bits", "always use the field id_str
+instead of id").
+
+**Correction to a common retelling:** the 2010 "Announcing Snowflake" engineering post does **not**
+mention JavaScript, 53 bits, or `id_str`. Its stated drivers were uncoordinated ID generation and
+sortability. Attribute the precision rationale to the API docs, never to the snowflake announcement.
+
+**Discord: use their wording, not the assumed reason.** Discord does serialize snowflakes as strings
+in the HTTP API and states that it transforms bigints into strings when serializing to JSON, but the
+reason it gives is "to prevent integer overflows in some languages." It never names JavaScript,
+IEEE 754, or 53 bits, and integer overflow is arguably a different failure mode from mantissa
+precision loss. Also, "always strings" is scoped to HTTP/JSON; the Gateway ETF docs say snowflakes
+are transmitted as 64-bit integers or strings. If Discord appears in the post, quote their reason
+and mark the parallel as the author's observation.
+
+---
+
+## The thesis
+
+Arrived at by talking it through out loud, and it is sharper than the earlier framings above.
+Prefer this one.
+
+> Every step of this bug was carried out by a component behaving correctly. It crossed three
+> processes, two CPU architectures, and one git commit. The place it was found and the place it was
+> caused are separated by a persistence boundary. The hard part was not the distance. It was that
+> **nothing along the path was broken**. The defect lives in the seam where two type systems fail to
+> line up, and nobody put a check on that seam.
+
+Supporting beats, each of which can carry a section:
+
+**Nobody has a bug.** controller-gen faithfully printed the float64 it held. The YAML parser
+faithfully read it back. The apiserver faithfully did what the Go specification permits. The marker
+was semantically reasonable. Walk the chain looking for wrong code and every link passes review.
+That is why you cannot bisect to it: there is no bad commit.
+
+**The marker was never seen by a compiler.** It is a comment. The compiler discards it during
+lexing. `controller-gen` is not a compilation phase; it is a separate tool that re-parses the source
+specifically to recover the comments the compiler threw away. So this is not "the compiler checked
+everything except this one thing." That text was never looked at by any compiler at all. What looks
+like a declaration is a string.
+
+**The bug crossed a persistence boundary.** It was born on a laptop and then frozen into a YAML file
+that was committed to git. By the time it detonated, that execution had happened weeks earlier, on a
+different machine, in a different process. You cannot attach a debugger to it, because half the
+"execution" is sitting in version control.
+
+**The evidence at the scene actively misleads.** The error message contains no number that appears
+anywhere in the source. And the platform split (same commit, ARM green, x86 red) reads as flaky
+infrastructure, which is where the investigation actually went first. The evidence is not merely
+thin, it points the wrong way.
+
+## Reader traps, worth using as targets
+
+These are not hypothetical. They came up while explaining the bug out loud, in this order, from
+someone who already understood the system. Each one is a natural, intelligent wrong turn, and every
+one of them pulls attention toward **text and parsing** when the real problem is a **type**. Naming
+and killing them in sequence is a ready-made spine.
+
+| Trap | What it assumes | The correction |
+|---|---|---|
+| 1. "CI is flaky" | Same commit passing and failing means infrastructure | One platform was failing for a real reason; another job's cancellation made the wrong story more convincing |
+| 2. "YAML is text, so it lost precision" | Serialized text is lossy | Text is the only lossless part. 19 characters hold the value perfectly |
+| 3. "Two parsers read the same string differently" | codegen and apiserver disagree on one input | They never read the same string. codegen read `...807`, apiserver read `...000`. Both parses are deterministic and both are correct |
+| 4. "The precision was lost when serializing" | The writer rounded it | It was already gone the moment the value entered a float64. The serializer printed its float64 exactly, and `9223372036854776000` is the shortest decimal that round-trips 2^63 |
+| 5. "This is an x86 problem" | The architecture caused it | The architecture only decides visibility. The value was already wrong on every machine |
+
+Trap 3 and trap 4 are the most valuable, because correcting them is what forces the reader to
+look at the data model instead of the file format.
+
+---
+
+## How this maps to the house style
+
+Read `WRITING-DNA.md` first. This section maps the material onto the established shape so the
+structural work is already done.
+
+**Warning about this file.** These notes are written with bullets, tables, and headings for
+scannability. The post allows none of that: zero bullet lists, `##` only, and tables are rare. Do
+not mirror this file's format. Mine it for content and rebuild in prose.
+
+**Proposed spine**, five sections, sentence case, readable as a story:
+
+1. `A bound that looked harmless` (the marker, and the sensible lint rule that produced it)
+2. `The first suspect` (the false-suspect beat: flaky infrastructure)
+3. `The number on disk` (Stage 1, rounding, identical on every machine)
+4. `Where the architectures disagree` (Stage 2, narrowing, the Go spec quote)
+5. `The fix` (drop the ceiling, the 2^53 rule, repro link, epigram)
+
+**Cold open draft**, action then consequence, thesis inside the first 100 words:
+
+> We put a ceiling on a CRD field so it could not hold nonsense. On ARM it worked. On x86 the
+> apiserver began rejecting every write, on the grounds that the value was larger than negative
+> nine quintillion.
+
+**The false-suspect beat is already in the material.** Same-commit-different-platform reads as
+flaky infrastructure, and one of the three CI jobs genuinely was an unrelated cancellation, which
+made the wrong theory more convincing. That is the "It hadn't." moment. The buried assumption to
+name afterwards: *a number written in Go source is the number the apiserver enforces.*
+
+**The `<Callout>` writes itself.** The house pattern is a verbatim quote of an authority followed
+by a flat read of it. Here the authority is the Go specification:
+
+> `<Callout>In all non-constant conversions involving floating-point or complex values, if the
+> result type cannot represent the value the conversion succeeds but the result value is
+> implementation-dependent.</Callout>`
+
+Then the read, in the manner of "It does exactly what it promises, which is less than it looks
+like." Something along the lines of: the spec is not describing an edge case, it is declining to
+have an opinion, and two CPUs took that as permission to disagree.
+
+**Footnote targets**, one per constant, each linking to a real upstream file:
+the Go specification section on conversions; the JSON Schema or OpenAPI definition of `maximum` as
+a JSON number; IEEE 754 double precision and the 53-bit significand; the ARM `FCVTZS` and x86
+`CVTTSD2SI` reference pages for their differing out-of-range behavior.
+
+**Diagram.** A `mermaid` sequenceDiagram fits: Go marker to codegen to YAML to apiserver, then the
+path forking by architecture at the narrowing step. Follow it with a `<FigCaption>` that states the
+conclusion rather than describing the picture, for example: the value is already wrong before it
+leaves the developer's machine; the architecture only decides whether the wrongness is visible.
+
+**Repro link.** GitHub tree URL, not the site path, in the paragraph before the closing epigram:
+`https://github.com/initor/blog-nextjs/tree/master/public/repro/ceiling-that-became-a-floor`
+
+**Closing epigram candidates**, sharpest line last:
+
+> The compiler knew. It just never got to see the number.
+
+> Go refuses to make this mistake at compile time. We handed it the number at runtime instead.
+
+---
+
+## The narrative arc
+
+The shape of the investigation, in the order it actually happened. This is the honest sequence,
+including the wrong turn, which is worth keeping because the wrong turn is the reader's wrong turn
+too.
+
+1. **The symptom.** A new CRD field ships. Locally, `bazel test ./...` passes 22/22, every run.
+   CI fails. Not intermittently: 15 of 15 runs on x86, while 3 of 3 on ARM pass.
+2. **The wrong turn.** Same-commit runs disagreeing by platform reads as flaky infrastructure. One
+   of the three CI jobs genuinely *was* an unrelated cancellation, which made the "infra flake"
+   story more convincing. It took reading the actual failing job (not the rollup) to see that one
+   platform was failing for a real reason and the others were noise.
+3. **The error message**, which is absurd on its face and is the hook for the post:
+
+   ```
+   Invalid value: 1: <field> in body should be less than or equal to -9223372036854775808
+   ```
+
+   A field whose declared maximum was the *largest* int64 is rejecting the value `1` for being
+   too large, against a bound that is the *smallest* int64. The ceiling became a floor.
+4. **The reveal.** Two separate precision events, only one of which is architecture-dependent.
+
+---
+
+## The mechanism, in two stages
+
+This two-stage framing is the core explanatory device. Keep it.
+
+| | Stage 1: Rounding | Stage 2: Narrowing |
+|---|---|---|
+| Where | codegen, on the dev machine | validation, inside the apiserver |
+| What | `MaxInt64` into a float64 | that float64 back into an int64 |
+| Architecture-dependent? | **No.** Identical everywhere | **Yes.** Undefined by the Go spec |
+| Result | YAML on disk says `9223372036854776000` | x86 gives `MinInt64`; ARM gives `MaxInt64` |
+
+**Stage 1 is the bug. Stage 2 only decides whether anyone finds out.**
+
+### Stage 1: the value is already wrong on disk
+
+The Go marker is ordinary and looks harmless:
+
+```go
+// +kubebuilder:validation:Minimum=1
+// +kubebuilder:validation:Maximum=9223372036854775807
+SomeGeneration int64 `json:"someGeneration"`
+```
+
+In JSON Schema and OpenAPI, `maximum` is a JSON *number*, and the Go structs modelling the schema
+hold it as a **float64**. float64 has a 53-bit mantissa; `MaxInt64` needs 63. So the value is
+rounded **at generation time, in Go, before any YAML is written**.
+
+The generated CRD, committed to the repo, literally contained:
+
+```yaml
+someGeneration:
+  format: int64                     # the field is an integer
+  maximum: 9223372036854776000      # the bound is a rounded float
+```
+
+`9223372036854776000` is exactly 2^63, which is `MaxInt64 + 1`. **The bound escaped the very range
+it was meant to cap.**
+
+> Correct a natural assumption here, because it is the one most readers will make: the loss is
+> **not** because YAML is text. Text is the only lossless part of this pipeline. `9223372036854775807`
+> is nineteen characters and YAML holds it perfectly. The loss is in the *data model* behind the
+> text. The artifact was already wrong before it was serialized. Nothing "got corrupted during
+> parsing"; the parser faithfully reproduced a bad number.
+
+### Stage 2: where the architectures part ways
+
+Validation must compare an `int64` field against that float64 bound, so something narrows 2^63 back
+to an int64. 2^63 does not fit. The Go specification declines to define what happens:
+
+> In all non-constant conversions involving floating-point or complex values, if the result type
+> cannot represent the value the conversion succeeds but the result value is
+> **implementation-dependent**.
+
+Two architectures, two answers:
+
+- **ARM64** (`FCVTZS`) **saturates** to `MaxInt64`. Which is, by pure accident, exactly the bound
+  that was originally intended. Validation behaves correctly.
+- **x86-64** (`CVTTSD2SI`) returns the "integer indefinite" value, `MinInt64`. The bound becomes
+  `<= -9223372036854775808`, so every write with a value of 1 or more is rejected.
+
+The irony worth landing: **ARM was not passing despite a bug. It was passing because a second
+undefined behavior happened to undo the first.**
+
+### The guardrail that cannot fire
+
+The strongest single fact. Go's compiler *does* catch this, but only for constants:
+
+```go
+const c = float64(9223372036854775807)
+_ = int64(c)
+```
+
+```
+cannot convert c (constant 9223372036854775808 of type float64) to type int64
+```
+
+The compiler evaluates it, sees the overflow, and refuses. Note it even reports the already-rounded
+value, 2^63, in its own error message.
+
+Move the identical value through a variable, which is exactly what parsing it from a YAML file
+does, and the conversion compiles clean and returns garbage at runtime. The safety net is real and
+is bypassed the moment the number crosses a file boundary.
+
+---
+
+## The transferable rule
+
+Do not write the takeaway as "avoid MaxInt64 in kubebuilder markers." The general form:
+
+> **Any integer bound above 2^53 is silently approximated the moment it enters an OpenAPI schema.**
+> The value the apiserver enforces is not the value you wrote.
+
+`9007199254740991` (2^53 - 1) round-trips exactly. `MaxInt64` cannot. This is a property of JSON
+Schema, not of Go or Kubernetes, so it applies to any language generating OpenAPI, and to
+request/response validation as much as to CRDs.
+
+There is a nice secondary tension: the internal coding standard that produced this said *"numeric
+fields need both Minimum and Maximum, because unbounded ints reach MaxInt32 and surface as nonsense
+at runtime."* That rule is good and the reasoning is sound. Applied to an int64 mirror field it
+produces this. The honest resolution was to drop the ceiling and document why, not to pick a
+slightly smaller wrong number. Worth a short section: **a well-intentioned lint rule can be the
+proximate cause.**
+
+---
+
+## Runnable reproduction
+
+House pattern is `public/repro/<slug>/` with `go.mod`, `main.go`, `README.md`, and a candid
+"honest caveat" section. This repro has an unusual property: **Stage 1 reproduces on any machine in
+under a second with zero dependencies.** No cluster, no CRDs, no kubebuilder.
+
+### Part 1: the rounding (deterministic, any machine)
+
+```go
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"math"
+)
+
+func main() {
+	const maxInt64 = int64(math.MaxInt64)
+	f := float64(maxInt64) // what an OpenAPI schema stores: a JSON number, i.e. a float64
+
+	fmt.Printf("as written in the marker : %d\n", maxInt64)
+	b, _ := json.Marshal(f)
+	fmt.Printf("after the float64 trip   : %s\n", b)
+	fmt.Printf("the float is exactly 2^63: %v\n", f == math.Pow(2, 63))
+
+	got := int64(f) // non-constant conversion: implementation-dependent
+	fmt.Printf("int64(2^63) here         : %d\n", got)
+	fmt.Printf("  saturated to MaxInt64? : %v\n", got == math.MaxInt64)
+	fmt.Printf("  indefinite MinInt64?   : %v\n", got == math.MinInt64)
+}
+```
+
+Measured output on Apple Silicon (darwin/arm64), verbatim:
+
+```
+as written in the marker : 9223372036854775807
+after the float64 trip   : 9223372036854776000
+the float is exactly 2^63: true
+int64(2^63) here         : 9223372036854775807
+  saturated to MaxInt64? : true
+  indefinite MinInt64?   : false
+```
+
+The first two lines are the bug and they print the same on every machine. The last three are the
+architecture-dependent part.
+
+### Part 2: the compile-time guardrail
+
+```go
+const c = float64(9223372036854775807)
+_ = int64(c) // compile error, verified
+```
+
+### Part 3: what Go actually emits on amd64
+
+Worth showing in the post, because it closes the mechanism with no hand-waving. Go's amd64 code
+generation for a `float64` to `int64` conversion is a single instruction with **no range check**.
+The whole function is six bytes:
+
+```
+GOOS=linux GOARCH=amd64 go build -gcflags=-S
+```
+
+```
+main.conv STEXT nosplit size=6
+	CVTTSD2SQ	X0, AX
+	RET
+	f2 48 0f 2c c0 c3
+```
+
+There is nowhere for a check to live. Intel documents `CVTTSD2SI` and its 64-bit form as returning
+the "integer indefinite" value when the source does not fit, which for 64 bits is
+`0x8000000000000000`, exactly `MinInt64`. That is the number in the production error message.
+
+### The honest caveat (write this section, do not skip it)
+
+This section got much more interesting after an attempt to shortcut it. Keep the whole story.
+
+**The rounding half reproduces anywhere.** Part 1's first three lines print identically on every
+machine, and that is the actual defect.
+
+**The divergence needs real x86 silicon, and emulation will lie to you.** The obvious shortcut on
+an Apple Silicon machine is to cross-compile and run the x86 binary locally:
+
+```
+GOOS=darwin GOARCH=amd64 go build -o maxint_amd64 maxint.go
+./maxint_amd64
+```
+
+The binary really is x86-64 (`file` confirms `Mach-O 64-bit executable x86_64`), it runs under
+Rosetta 2, and it prints **the ARM answer**: saturated to `MaxInt64`, not the indefinite
+`MinInt64`. Verified in-session. Since Go provably emits a bare `CVTTSD2SQ` for this conversion
+(Part 3), the translation layer is not reproducing the instruction's documented out-of-range
+behavior.
+
+`docker run --platform linux/amd64` was **not** tested (Docker was not running). Depending on
+configuration it may use Rosetta or QEMU, so treat it as unverified until it is checked. The safe
+instruction to readers is: run it on real x86 hardware, or verify your emulator reproduces it
+before trusting a negative result.
+
+This is a genuinely good beat rather than a weakness. The bug is invisible on ARM, and it stays
+invisible when you emulate x86 on ARM to go looking for it. Two layers of accidental concealment.
+
+**The x86 evidence is observational, not locally reproduced.** The `-9223372036854775808` error
+string came from real CI logs on two independent x86 images, while ARM passed on the same commit,
+and all three went green after the marker was removed. Strong, but it is production evidence.
+
+**The end-to-end path was never reproduced in one script.** Marker to apiserver rejection needs a
+real apiserver with the generated CRD applied. Decide whether a `kind` cluster plus a two-field toy
+CRD earns its setup cost, or whether the honest framing is "here is the mechanism, here is the
+production evidence."
+
+---
+
+## Evidence table
+
+| Claim | Verified how |
+|---|---|
+| Marker `Maximum=9223372036854775807` generates `maximum: 9223372036854776000` | Read the committed generated CRD YAML in git history |
+| That literal equals 2^63, i.e. `MaxInt64 + 1` | Go program, output above |
+| `MaxInt64` is not exactly representable as float64 | Go program, output above |
+| ARM64 narrows 2^63 to `MaxInt64` | Ran it on darwin/arm64, output above |
+| Go emits a bare `CVTTSD2SQ` with no range check on amd64 | `go build -gcflags=-S`, six-byte function, quoted above |
+| x86-64 narrows 2^63 to `MinInt64` | CI logs on two x86 images: error names `-9223372036854775808` |
+| An x86-64 binary under Rosetta 2 gives the ARM answer, not the x86 one | Cross-compiled `GOARCH=amd64`, confirmed x86-64 via `file`, ran it, got `MaxInt64` |
+| Docker `--platform linux/amd64` behavior | **Not tested.** Docker was not running |
+| ARM passes, x86 fails, same commit | CI run history: ARM green, x86 red, then green on both after removing the marker |
+| Constant conversion is a compile error | `go vet` and `go build`, message quoted above |
+| Removing the two `maximum:` lines fixes it | The fix commit turned CI green on all three platforms |
+
+---
+
+## Scope and disclosure
+
+The material above is deliberately generic and is safe to publish. It is a property of JSON Schema,
+OpenAPI, Go, and CPU instruction semantics. None of it is proprietary.
+
+**Keep out of the post.** The originating work is internal. Do not name or allude to: the employer's
+internal CRD kinds or field names, the controller or feature the field belonged to, internal PR
+numbers, internal ticket IDs, internal CI job or image names, internal repository paths, or the
+internal coding-standards document. Where context is unavoidable, say "a Kubernetes controller I
+work on" and use a neutral invented field such as `someGeneration` on a `Widget` CRD, as this file
+already does.
+
+The one internal detail worth generalizing rather than deleting is the coding rule about pairing
+Minimum with Maximum. Describe it as a common, sensible lint rule, not as a specific document.
+
+---
+
+## Companion post, captured so it is not lost
+
+The same session found a second bug with the same theme, **nondeterminism your local tests cannot
+see**. It is a separate post, and the two would pair well as a set.
+
+A controller built a slice by ranging over a Go map, so the emitted element order varied between
+reconciles. The Kubernetes object write path skips the write when the new object deep-equals the
+old one, but that comparison is **positional for slices**. So an unchanged desired state still
+produced a write, and the apiserver bumped `metadata.generation`. A feature that anchored a timer
+on that generation had its timer reset by unrelated traffic, so the timeout could be deferred
+indefinitely.
+
+Measured flip rate on a two-key map: **17450 / 2550 across 20000 iterations**, about 13% per
+reconcile. Enough that in a busy cluster the timer effectively never accumulated.
+
+The transferable lesson: **`DeepEqual` on a slice is an ordering assertion.** Building the slice
+from a map makes every no-op reconcile a coin flip. Go randomizes map iteration deliberately, to
+stop exactly this kind of accidental dependency, and the randomization here turned into a write
+amplifier.
+
+Fix was three lines of sort. Verified by disabling the sort and confirming both regression tests
+fail.

--- a/.planning/post-material/crd-maximum-bug-lifecycle-2026-07-25.html
+++ b/.planning/post-material/crd-maximum-bug-lifecycle-2026-07-25.html
@@ -1,0 +1,368 @@
+<!DOCTYPE html>
+<html lang="zh-CN" data-theme="auto" data-anim="off">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>CRD 上限反转：一个 bug 的生命周期</title>
+<style>
+/* ---------- base ---------- */
+* { box-sizing: border-box; }
+html { scroll-behavior: smooth; }
+body {
+  margin: 0; background: var(--bg-primary); color: var(--text-primary);
+  font-family: var(--font-text); font-size: var(--body-size); line-height: 1.5;
+  -webkit-font-smoothing: antialiased;
+  transition: background-color .3s ease, color .3s ease;
+}
+main { max-width: var(--max-width); margin: 0 auto; padding: 0 24px; }
+h1,h2,h3 { font-family: var(--font-display); line-height: 1.12; margin: 0 0 .4em; }
+
+.hero {
+  min-height: var(--hero-min-h); display: flex; flex-direction: column;
+  justify-content: center; padding: 96px 0 48px;
+}
+.hero h1 { font-size: var(--hero-title-size); letter-spacing: -.01em; }
+.hero .subtitle { color: var(--text-secondary); font-size: 1.18rem; max-width: 60ch; }
+
+.section { padding: var(--section-pad-y) 0; border-top: 1px solid var(--border); }
+.section > h2 { font-size: var(--section-title-size); }
+.section p { color: var(--text-secondary); max-width: 70ch; }
+
+.card-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(220px,1fr)); gap: 20px; }
+.card {
+  background: var(--card-bg); border: var(--card-border); box-shadow: var(--card-shadow);
+  border-radius: var(--card-radius); padding: var(--card-pad);
+}
+
+.metric .value { font-family: var(--font-display); font-size: 2.6rem; font-weight: 700; color: var(--accent); letter-spacing: -.02em; }
+.metric .label { color: var(--text-secondary); font-size: .82rem; text-transform: uppercase; letter-spacing: .05em; }
+
+.tbl { width: 100%; border-collapse: collapse; }
+.tbl th { text-align: left; padding: 10px 14px; border-bottom: 2px solid var(--border); font-weight: 600; }
+.tbl td { padding: 10px 14px; border-bottom: 1px solid var(--border); }
+.tbl .yes { color: var(--success); } .tbl .no { color: var(--danger); }
+
+.code { background: var(--code-bg); border: 1px solid var(--border); border-radius: 10px; padding: 16px; overflow:auto;
+  font-family: var(--font-mono); font-size: .86rem; line-height: 1.55; }
+
+.callout { border-left: 3px solid var(--accent); background: var(--bg-secondary); border-radius: 0 10px 10px 0; padding: 16px 20px; margin: 20px 0; }
+.callout.warn { border-color: var(--warning); } .callout.danger { border-color: var(--danger); }
+
+#theme-toggle { position: fixed; top: 18px; right: 18px; z-index: 1000;
+  width: 38px; height: 38px; border-radius: 50%; border: 1px solid var(--border);
+  background: var(--card-bg); color: var(--text-primary); cursor: pointer; display: grid; place-items: center; }
+
+.reveal { opacity: 0; transform: translateY(16px); transition: opacity .6s ease, transform .6s ease; }
+.reveal.visible { opacity: 1; transform: none; }
+[data-anim="off"] .reveal { opacity: 1; transform: none; transition: none; }
+
+@media (max-width: 740px) {
+  :root { --hero-title-size: 32px; --section-pad-y: 44px; }
+  main { padding: 0 18px; }
+}
+@media (prefers-reduced-motion: reduce) { .reveal, body { transition: none; } }
+
+/* ---------- flavor: minimal ---------- */
+:root {
+  --font-display: ui-sans-serif, system-ui, -apple-system, "PingFang SC", "Hiragino Sans GB", "Microsoft YaHei", sans-serif;
+  --font-text:    ui-sans-serif, system-ui, -apple-system, "PingFang SC", "Hiragino Sans GB", "Microsoft YaHei", sans-serif;
+  --font-mono:    ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+
+  --bg-primary:#ffffff; --bg-secondary:#f5f5f7; --bg-tertiary:#e8e8ed;
+  --text-primary:#1d1d1f; --text-secondary:#6e6e73; --text-tertiary:#86868b;
+  --accent:#0a84d6; --accent-hover:#0a74bd; --accent-subtle:rgba(10,132,214,.08);
+  --success:#34a853; --warning:#e8910a; --danger:#e0392f;
+  --border:rgba(0,0,0,.08); --card-bg:#ffffff; --card-shadow:none; --code-bg:#f5f5f7;
+
+  --max-width:720px;
+  --section-pad-y:52px;
+  --hero-min-h:auto;
+  --hero-title-size:34px;
+  --section-title-size:22px;
+  --body-size:17px;
+  --card-radius:8px;
+  --card-pad:20px;
+  --card-border:1px solid var(--border);
+}
+[data-theme="dark"] {
+  --bg-primary:#000000; --bg-secondary:#1c1c1e; --bg-tertiary:#2c2c2e;
+  --text-primary:#f5f5f7; --text-secondary:#a1a1a6; --text-tertiary:#86868b;
+  --accent:#2997ff; --accent-hover:#4aa9ff; --accent-subtle:rgba(41,151,255,.14);
+  --success:#30d158; --warning:#ffd60a; --danger:#ff453a;
+  --border:rgba(255,255,255,.10); --card-bg:#1c1c1e; --card-shadow:none; --code-bg:#1c1c1e;
+}
+.hero { min-height: auto; padding: 64px 0 24px; }
+.hero .subtitle { font-size: 1.05rem; }
+.metric .value { font-size: 2rem; }
+.section > h2 { letter-spacing: -.005em; }
+
+/* ---------- page-specific (tokens only) ---------- */
+.steps { list-style: none; margin: 28px 0 0; padding: 0; }
+.step { position: relative; padding: 0 0 30px 34px; border-left: 1px solid var(--border); }
+.step:last-child { border-left-color: transparent; padding-bottom: 0; }
+.step::before {
+  content: ""; position: absolute; left: -5px; top: 5px; width: 9px; height: 9px;
+  border-radius: 50%; background: var(--bg-primary); border: 1px solid var(--text-tertiary);
+}
+.step.mark::before { background: var(--danger); border-color: var(--danger); width: 11px; height: 11px; left: -6px; }
+.step .n { font-family: var(--font-mono); font-size: .74rem; color: var(--text-tertiary); letter-spacing: .06em; }
+.step h3 { font-size: 1.02rem; margin: 2px 0 8px; }
+.step dl { margin: 0; display: grid; grid-template-columns: 4.2em 1fr; gap: 4px 12px; }
+.step dt { color: var(--text-tertiary); font-size: .84rem; }
+.step dd { margin: 0; color: var(--text-secondary); font-size: .92rem; }
+.step dd code, .step dd .m { font-family: var(--font-mono); font-size: .86em; color: var(--text-primary); }
+.tag { display: inline-block; font-size: .76rem; padding: 1px 8px; border-radius: 999px;
+  border: 1px solid var(--border); color: var(--text-secondary); }
+.tag.ok { color: var(--success); border-color: var(--success); }
+.tag.bad { color: var(--danger); border-color: var(--danger); }
+.tag.neutral { color: var(--text-tertiary); }
+.step.mark { background: var(--accent-subtle); border-radius: 0 8px 8px 0; margin-left: -1px;
+  padding-left: 35px; padding-top: 4px; padding-right: 14px; }
+.fig { margin: 24px 0 8px; }
+.fig svg { width: 100%; height: auto; display: block; }
+.figcap { color: var(--text-tertiary); font-size: .84rem; margin-top: 10px; }
+.lede { font-size: 1.06rem; color: var(--text-primary); max-width: 62ch; }
+</style>
+</head>
+<body>
+<button id="theme-toggle" aria-label="切换配色"></button>
+<main>
+
+<header class="hero">
+  <h1>CRD 上限反转</h1>
+  <p class="subtitle">我写的是「最大值 = 最大的整数」，apiserver 最后执行的是「最大值 = 最小的整数」。中间经过两次数字变形，只有第二次跟 CPU 架构有关。</p>
+</header>
+
+<section class="section">
+  <h2>四个数字</h2>
+  <div class="card-grid" style="margin-top:22px">
+    <div class="card metric"><div class="value">53</div><div class="label">float64 尾数位</div><p style="margin:.5em 0 0;font-size:.88rem">MaxInt64 需要 63 位，装不下。</p></div>
+    <div class="card metric"><div class="value">+1</div><div class="label">上限溢出量</div><p style="margin:.5em 0 0;font-size:.88rem">四舍五入后的上限，比它要限制的最大值大 1。</p></div>
+    <div class="card metric"><div class="value">6</div><div class="label">字节（amd64 转换函数）</div><p style="margin:.5em 0 0;font-size:.88rem">一条裸指令加返回，没有范围检查的余地。</p></div>
+    <div class="card metric"><div class="value">6834</div><div class="label">单次 x86 CI 中的拒绝次数</div><p style="margin:.5em 0 0;font-size:.88rem">同一 commit 在 ARM 上零次。</p></div>
+  </div>
+</section>
+
+<section class="section">
+  <h2>生命周期</h2>
+  <p class="lede">从我敲下一行标注，到 apiserver 拒绝一个值为 <span style="font-family:var(--font-mono)">1</span> 的写入。七步，两个节点出问题。</p>
+
+  <ol class="steps">
+
+    <li class="step">
+      <div class="n">STEP 01</div>
+      <h3>写代码</h3>
+      <dl>
+        <dt>谁</dt><dd>我</dd>
+        <dt>做什么</dt><dd>给一个 int64 字段加上限标注 <code>Maximum=9223372036854775807</code></dd>
+        <dt>输出</dt><dd>Go 源码里的一行注释</dd>
+        <dt>状态</dt><dd><span class="tag ok">正确</span> 这就是 int64 能表示的最大值</dd>
+      </dl>
+    </li>
+
+    <li class="step mark">
+      <div class="n">STEP 02　·　BUG 在这里产生</div>
+      <h3>代码生成（controller-gen）</h3>
+      <dl>
+        <dt>谁</dt><dd>controller-gen，跑在我自己的笔记本上</dd>
+        <dt>做什么</dt><dd>读标注，生成 CRD YAML。OpenAPI 规定 <code>maximum</code> 是 JSON 数字，内部用 <strong>float64</strong> 存，53 位精度装不下 63 位，被四舍五入</dd>
+        <dt>输出</dt><dd><span class="m">maximum: 9223372036854776000</span>　（也就是 2<sup>63</sup>，比 MaxInt64 大 1）</dd>
+        <dt>状态</dt><dd><span class="tag bad">已损坏</span> 与 CPU 架构无关，哪台机器都一样</dd>
+      </dl>
+    </li>
+
+    <li class="step">
+      <div class="n">STEP 03</div>
+      <h3>提交进 git</h3>
+      <dl>
+        <dt>谁</dt><dd>我</dd>
+        <dt>做什么</dt><dd><code>git commit</code></dd>
+        <dt>输出</dt><dd>仓库里存了一个已经错了的 YAML</dd>
+        <dt>状态</dt><dd><span class="tag neutral">无人察觉</span> code review 时那就是一串长数字，肉眼看不出它多了 1</dd>
+      </dl>
+    </li>
+
+    <li class="step">
+      <div class="n">STEP 04</div>
+      <h3>部署到集群</h3>
+      <dl>
+        <dt>谁</dt><dd>helm / kubectl</dd>
+        <dt>做什么</dt><dd>把 CRD 装进 apiserver</dd>
+        <dt>输出</dt><dd>apiserver 里存着这个 schema</dd>
+        <dt>状态</dt><dd><span class="tag neutral">无损</span> 文本原样传递，这一步没破坏任何东西</dd>
+      </dl>
+    </li>
+
+    <li class="step">
+      <div class="n">STEP 05</div>
+      <h3>控制器写状态</h3>
+      <dl>
+        <dt>谁</dt><dd>我的 controller</dd>
+        <dt>做什么</dt><dd>往对象 status 写 <code>someGeneration = 1</code></dd>
+        <dt>输出</dt><dd>一个写请求发给 apiserver</dd>
+        <dt>状态</dt><dd><span class="tag ok">正常</span> 值是 1，再普通不过</dd>
+      </dl>
+    </li>
+
+    <li class="step mark">
+      <div class="n">STEP 06　·　BUG 在这里显形</div>
+      <h3>apiserver 校验</h3>
+      <dl>
+        <dt>谁</dt><dd>apiserver</dd>
+        <dt>做什么</dt><dd>拿 schema 里的 float64 上限跟 int64 字段比较，必须先把 2<sup>63</sup> 转回 int64。Go 规范对越界转换<strong>明确不做规定</strong>，原文是「结果值由实现决定」</dd>
+        <dt>输出</dt><dd>ARM：上限 = <span class="m">9223372036854775807</span>　·　x86：上限 = <span class="m">-9223372036854775808</span></dd>
+        <dt>状态</dt><dd><span class="tag bad">取决于 CPU</span> 同一份 YAML，两种结果</dd>
+      </dl>
+    </li>
+
+    <li class="step">
+      <div class="n">STEP 07</div>
+      <h3>结果</h3>
+      <dl>
+        <dt>谁</dt><dd>CI</dd>
+        <dt>做什么</dt><dd>在三个平台上跑同一个 commit</dd>
+        <dt>输出</dt><dd>本地 ARM 全绿，CI ARM 通过，CI x86 全红</dd>
+        <dt>状态</dt><dd><span class="tag bad">看起来像基础设施抖动</span> 而不是代码问题</dd>
+      </dl>
+    </li>
+
+  </ol>
+</section>
+
+<section class="section">
+  <h2>第 6 步的分岔</h2>
+  <div class="fig">
+    <svg viewBox="0 0 700 260" role="img" aria-label="float64 2 的 63 次方 在两种架构上转换为 int64 的分岔流程图">
+      <defs>
+        <marker id="ar" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+          <path d="M0,0 L10,5 L0,10 z" fill="var(--text-tertiary)"/>
+        </marker>
+      </defs>
+      <g font-family="var(--font-text)" font-size="13">
+        <rect x="8" y="104" width="176" height="52" rx="8" fill="var(--bg-secondary)" stroke="var(--border)"/>
+        <text x="96" y="126" text-anchor="middle" fill="var(--text-primary)" font-size="12">schema 里的上限</text>
+        <text x="96" y="144" text-anchor="middle" fill="var(--text-primary)" font-family="var(--font-mono)" font-size="12">float64 = 2^63</text>
+
+        <path d="M184,130 Q232,130 232,72 Q232,52 268,52" fill="none" stroke="var(--text-tertiary)" stroke-width="1.2" marker-end="url(#ar)"/>
+        <path d="M184,130 Q232,130 232,188 Q232,208 268,208" fill="none" stroke="var(--text-tertiary)" stroke-width="1.2" marker-end="url(#ar)"/>
+
+        <rect x="272" y="26" width="188" height="52" rx="8" fill="var(--bg-secondary)" stroke="var(--success)"/>
+        <text x="366" y="47" text-anchor="middle" fill="var(--text-primary)" font-size="12">ARM64　FCVTZS</text>
+        <text x="366" y="65" text-anchor="middle" fill="var(--text-secondary)" font-size="11.5">饱和，压到最大值</text>
+
+        <rect x="272" y="182" width="188" height="52" rx="8" fill="var(--bg-secondary)" stroke="var(--danger)"/>
+        <text x="366" y="203" text-anchor="middle" fill="var(--text-primary)" font-size="12">x86-64　CVTTSD2SQ</text>
+        <text x="366" y="221" text-anchor="middle" fill="var(--text-secondary)" font-size="11.5">返回「整数不定值」</text>
+
+        <path d="M460,52 L516,52" fill="none" stroke="var(--text-tertiary)" stroke-width="1.2" marker-end="url(#ar)"/>
+        <path d="M460,208 L516,208" fill="none" stroke="var(--text-tertiary)" stroke-width="1.2" marker-end="url(#ar)"/>
+
+        <rect x="520" y="26" width="172" height="52" rx="8" fill="none" stroke="var(--success)"/>
+        <text x="606" y="46" text-anchor="middle" fill="var(--text-primary)" font-family="var(--font-mono)" font-size="11">MaxInt64</text>
+        <text x="606" y="65" text-anchor="middle" fill="var(--success)" font-size="12">校验 1　通过</text>
+
+        <rect x="520" y="182" width="172" height="52" rx="8" fill="none" stroke="var(--danger)"/>
+        <text x="606" y="202" text-anchor="middle" fill="var(--text-primary)" font-family="var(--font-mono)" font-size="11">MinInt64</text>
+        <text x="606" y="221" text-anchor="middle" fill="var(--danger)" font-size="12">校验 1　拒绝</text>
+      </g>
+    </svg>
+  </div>
+  <p class="figcap">同一个 float64，两条指令，两个相反的答案。ARM 的饱和行为恰好把第 2 步的损坏又还原成了我本来想要的那个数，所以它不是「有 bug 但没影响」，而是一个未定义行为碰巧抵消了另一个。</p>
+
+  <div class="callout danger">
+    <p style="margin:0;color:var(--text-primary)">x86 上的报错读起来很荒谬：一个声明「上限是最大整数」的字段，嫌 <span style="font-family:var(--font-mono)">1</span> 太大了。</p>
+    <div class="code" style="margin-top:12px">Invalid value: 1: someGeneration in body
+  should be less than or equal to -9223372036854775808</div>
+  </div>
+</section>
+
+<section class="section">
+  <h2>两个节点，性质完全不同</h2>
+  <p>这是理解整件事的关键。第 2 步才是 bug 本身，第 6 步只决定你会不会发现它。</p>
+  <table class="tbl" style="margin-top:18px">
+    <thead><tr><th></th><th>第 2 步：四舍五入</th><th>第 6 步：转换</th></tr></thead>
+    <tbody>
+      <tr><td>在哪</td><td>我笔记本上的 codegen</td><td>apiserver 里</td></tr>
+      <tr><td>干了什么</td><td>MaxInt64 塞进 float64</td><td>float64 转回 int64</td></tr>
+      <tr><td>跟 CPU 有关吗</td><td class="yes">无关，哪台机器都一样</td><td class="no">有关，规范没定义</td></tr>
+      <tr><td>结果</td><td>YAML 里存了 2<sup>63</sup></td><td>ARM 给 MaxInt64，x86 给 MinInt64</td></tr>
+      <tr><td>角色</td><td><strong>bug 本身</strong></td><td>只是让它显形</td></tr>
+    </tbody>
+  </table>
+
+  <div class="callout warn">
+    <p style="margin:0;color:var(--text-primary)">要纠正一个很自然的直觉：损坏<strong>不是</strong>因为「YAML 是文本所以丢精度」。文本恰恰是整条链路里唯一不丢精度的部分，19 个字符它存得好好的。真正丢精度的是 float64。<strong>文件写出来之前，数字就已经错了</strong>，解析器只是忠实地读回了一个错的数。</p>
+  </div>
+</section>
+
+<section class="section">
+  <h2>为什么本地怎么测都测不出来</h2>
+  <p>开发机是 Apple Silicon，也就是 ARM。所以本地测试全绿，提供的信息是零。</p>
+  <table class="tbl" style="margin-top:18px">
+    <thead><tr><th>环境</th><th>架构</th><th>结果</th></tr></thead>
+    <tbody>
+      <tr><td>本地 <span style="font-family:var(--font-mono);font-size:.9em">bazel test</span></td><td>ARM64</td><td class="yes">22/22 通过，每次都通过</td></tr>
+      <tr><td>CI</td><td>ARM64</td><td class="yes">通过</td></tr>
+      <tr><td>CI</td><td>x86-64</td><td class="no">失败，同一个 commit</td></tr>
+      <tr><td>交叉编译 + Rosetta 2</td><td>x86-64 二进制跑在 ARM 上</td><td class="yes">返回 ARM 的答案</td></tr>
+    </tbody>
+  </table>
+  <p style="margin-top:16px">最后一行是这次实测出来的：在 Mac 上交叉编译一个真正的 x86-64 二进制（<span style="font-family:var(--font-mono);font-size:.9em">file</span> 确认无误），用 Rosetta 2 跑，它返回的是饱和后的 MaxInt64，不是 x86 的 MinInt64。所以这个 bug 在 ARM 上藏着，你在 ARM 上模拟 x86 去抓它，它还是藏着。两层意外的遮蔽。</p>
+</section>
+
+<section class="section">
+  <h2>编译器其实知道</h2>
+  <p>把同样的转换写成常量，Go 直接拒绝编译：</p>
+  <div class="code">const c = float64(9223372036854775807)
+_ = int64(c)
+
+<span style="color:var(--danger)">cannot convert c (constant 9223372036854775808 of type float64) to type int64</span></div>
+  <p style="margin-top:14px">注意它报的已经是四舍五入之后的 2<sup>63</sup>。而 amd64 上运行期的那次转换，整个函数只有 6 个字节：</p>
+  <div class="code">main.conv STEXT nosplit size=6
+	CVTTSD2SQ	X0, AX
+	RET
+	f2 48 0f 2c c0 c3</div>
+  <p style="margin-top:14px">裸指令，没有任何检查的余地。</p>
+
+  <div class="callout">
+    <p style="margin:0;color:var(--text-primary)">护栏是存在的，但它只在编译期起作用。数字一旦经过一个 YAML 文件、以变量的形式在运行时到达，护栏就绕过去了：转换悄悄成功，返回一个垃圾值。</p>
+  </div>
+</section>
+
+<section class="section">
+  <h2>可以带走的规则</h2>
+  <div class="callout">
+    <p style="margin:0;color:var(--text-primary);font-size:1.04rem">任何超过 2<sup>53</sup> 的整数上限，一进 OpenAPI schema 就会被悄悄近似。<strong>apiserver 真正执行的，不是你写的那个数。</strong></p>
+  </div>
+  <p><span style="font-family:var(--font-mono);font-size:.9em">9007199254740991</span>（2<sup>53</sup> 减 1）能完好往返，MaxInt64 不能。这是 JSON Schema 的性质，跟 Go 和 Kubernetes 都无关，所以换任何语言生成 OpenAPI 都一样，请求响应校验和 CRD 一视同仁。</p>
+  <p>最后一层张力：导致这个问题的那条编码规范说的是「数值字段要同时写 Minimum 和 Maximum，否则会跑到 MaxInt32 变成运行时的垃圾值」。这条规则本身是对的，理由也成立，只是套在一个 int64 字段上就长出了这个 bug。所以诚实的修法是<strong>把上限去掉并写清楚为什么</strong>，而不是换一个稍微小一点的错数字。</p>
+</section>
+
+</main>
+<script>
+const root = document.documentElement;
+const saved = localStorage.getItem('paint-theme');
+if (saved) root.dataset.theme = saved;
+if (root.dataset.theme === 'auto')
+  root.dataset.theme = matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+const SUN = '<svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="4"/><path d="M12 2v2M12 20v2M4.9 4.9l1.4 1.4M17.7 17.7l1.4 1.4M2 12h2M20 12h2M4.9 19.1l1.4-1.4M17.7 6.3l1.4-1.4"/></svg>';
+const MOON = '<svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M21 12.8A9 9 0 1111.2 3 7 7 0 0021 12.8z"/></svg>';
+const btn = document.getElementById('theme-toggle');
+const paintIcon = () => btn.innerHTML = root.dataset.theme === 'dark' ? SUN : MOON;
+paintIcon();
+btn.addEventListener('click', () => {
+  root.dataset.theme = root.dataset.theme === 'dark' ? 'light' : 'dark';
+  localStorage.setItem('paint-theme', root.dataset.theme);
+  paintIcon();
+});
+if (root.dataset.anim !== 'off') {
+  const io = new IntersectionObserver((es) => es.forEach(e => {
+    if (e.isIntersecting) { e.target.classList.add('visible'); io.unobserve(e.target); }
+  }), { threshold: .12 });
+  document.querySelectorAll('.reveal').forEach(el => io.observe(el));
+} else {
+  document.querySelectorAll('.reveal').forEach(el => el.classList.add('visible'));
+}
+</script>
+</body>
+</html>

--- a/.planning/post-material/defect-landscape-openapi-int64-2026-07-26.html
+++ b/.planning/post-material/defect-landscape-openapi-int64-2026-07-26.html
@@ -1,0 +1,293 @@
+<!DOCTYPE html>
+<html lang="zh-CN" data-theme="auto" data-anim="off">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>缺陷全景：查错属性的护栏，与三层规范的沉默</title>
+<style>
+/* ---------- base ---------- */
+* { box-sizing: border-box; }
+html { scroll-behavior: smooth; }
+body { margin: 0; background: var(--bg-primary); color: var(--text-primary);
+  font-family: var(--font-text); font-size: var(--body-size); line-height: 1.5;
+  -webkit-font-smoothing: antialiased; transition: background-color .3s ease, color .3s ease; }
+main { max-width: var(--max-width); margin: 0 auto; padding: 0 24px; }
+h1,h2,h3 { font-family: var(--font-display); line-height: 1.12; margin: 0 0 .4em; }
+.hero { min-height: var(--hero-min-h); display: flex; flex-direction: column; justify-content: center; padding: 96px 0 48px; }
+.hero h1 { font-size: var(--hero-title-size); letter-spacing: -.01em; }
+.hero .subtitle { color: var(--text-secondary); font-size: 1.18rem; max-width: 60ch; }
+.section { padding: var(--section-pad-y) 0; border-top: 1px solid var(--border); }
+.section > h2 { font-size: var(--section-title-size); }
+.section p { color: var(--text-secondary); max-width: 70ch; }
+.card-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(220px,1fr)); gap: 20px; }
+.card { background: var(--card-bg); border: var(--card-border); box-shadow: var(--card-shadow); border-radius: var(--card-radius); padding: var(--card-pad); }
+.metric .value { font-family: var(--font-display); font-size: 2.6rem; font-weight: 700; color: var(--accent); letter-spacing: -.02em; }
+.metric .label { color: var(--text-secondary); font-size: .82rem; text-transform: uppercase; letter-spacing: .05em; }
+.tbl { width: 100%; border-collapse: collapse; }
+.tbl th { text-align: left; padding: 10px 14px; border-bottom: 2px solid var(--border); font-weight: 600; }
+.tbl td { padding: 10px 14px; border-bottom: 1px solid var(--border); vertical-align: top; }
+.tbl .yes { color: var(--success); } .tbl .no { color: var(--danger); }
+.code { background: var(--code-bg); border: 1px solid var(--border); border-radius: 10px; padding: 16px; overflow:auto;
+  font-family: var(--font-mono); font-size: .86rem; line-height: 1.55; }
+.callout { border-left: 3px solid var(--accent); background: var(--bg-secondary); border-radius: 0 10px 10px 0; padding: 16px 20px; margin: 20px 0; }
+.callout.warn { border-color: var(--warning); } .callout.danger { border-color: var(--danger); }
+#theme-toggle { position: fixed; top: 18px; right: 18px; z-index: 1000; width: 38px; height: 38px; border-radius: 50%;
+  border: 1px solid var(--border); background: var(--card-bg); color: var(--text-primary); cursor: pointer; display: grid; place-items: center; }
+.reveal { opacity: 0; transform: translateY(16px); transition: opacity .6s ease, transform .6s ease; }
+.reveal.visible { opacity: 1; transform: none; }
+[data-anim="off"] .reveal { opacity: 1; transform: none; transition: none; }
+@media (max-width: 740px) { :root { --hero-title-size: 32px; --section-pad-y: 44px; } main { padding: 0 18px; } }
+@media (prefers-reduced-motion: reduce) { .reveal, body { transition: none; } }
+
+/* ---------- flavor: minimal ---------- */
+:root {
+  --font-display: ui-sans-serif, system-ui, -apple-system, "PingFang SC", "Hiragino Sans GB", "Microsoft YaHei", sans-serif;
+  --font-text:    ui-sans-serif, system-ui, -apple-system, "PingFang SC", "Hiragino Sans GB", "Microsoft YaHei", sans-serif;
+  --font-mono:    ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+  --bg-primary:#ffffff; --bg-secondary:#f5f5f7; --bg-tertiary:#e8e8ed;
+  --text-primary:#1d1d1f; --text-secondary:#6e6e73; --text-tertiary:#86868b;
+  --accent:#0a84d6; --accent-hover:#0a74bd; --accent-subtle:rgba(10,132,214,.08);
+  --success:#34a853; --warning:#e8910a; --danger:#e0392f;
+  --border:rgba(0,0,0,.08); --card-bg:#ffffff; --card-shadow:none; --code-bg:#f5f5f7;
+  --max-width:720px; --section-pad-y:52px; --hero-min-h:auto;
+  --hero-title-size:34px; --section-title-size:22px; --body-size:17px;
+  --card-radius:8px; --card-pad:20px; --card-border:1px solid var(--border);
+}
+[data-theme="dark"] {
+  --bg-primary:#000000; --bg-secondary:#1c1c1e; --bg-tertiary:#2c2c2e;
+  --text-primary:#f5f5f7; --text-secondary:#a1a1a6; --text-tertiary:#86868b;
+  --accent:#2997ff; --accent-hover:#4aa9ff; --accent-subtle:rgba(41,151,255,.14);
+  --success:#30d158; --warning:#ffd60a; --danger:#ff453a;
+  --border:rgba(255,255,255,.10); --card-bg:#1c1c1e; --card-shadow:none; --code-bg:#1c1c1e;
+}
+.hero { min-height: auto; padding: 64px 0 24px; }
+.hero .subtitle { font-size: 1.05rem; }
+.metric .value { font-size: 2rem; }
+.section > h2 { letter-spacing: -.005em; }
+
+/* ---------- page-specific (tokens only) ---------- */
+.fig { margin: 26px 0 8px; }
+.fig svg { width: 100%; height: auto; display: block; }
+.figcap { color: var(--text-tertiary); font-size: .84rem; margin-top: 10px; }
+.mono { font-family: var(--font-mono); font-size: .88em; }
+.lede { font-size: 1.06rem; color: var(--text-primary); max-width: 62ch; }
+.pill { display: inline-block; font-size: .74rem; padding: 1px 8px; border-radius: 999px; border: 1px solid var(--border); color: var(--text-secondary); white-space: nowrap; }
+.pill.open { color: var(--danger); border-color: var(--danger); }
+.pill.none { color: var(--text-tertiary); }
+.pill.has { color: var(--success); border-color: var(--success); }
+.layer { border: 1px solid var(--border); border-radius: var(--card-radius); padding: 16px 18px; margin: 14px 0; }
+.layer h3 { font-size: .97rem; margin: 0 0 6px; }
+.layer .said { font-size: .9rem; color: var(--text-primary); margin: 0 0 6px; }
+.layer .gap { font-size: .87rem; color: var(--text-secondary); margin: 0; }
+</style>
+</head>
+<body>
+<button id="theme-toggle" aria-label="切换配色"></button>
+<main>
+
+<header class="hero">
+  <h1>缺陷全景</h1>
+  <p class="subtitle">重新推敲后的根因不是「没人检查」，而是「有人检查了，检查了错的属性」。围绕它的，是三层规范的沉默、一个上游从未被提出的 issue，以及若干活在公开 spec 里的同款数字。</p>
+</header>
+
+<section class="section">
+  <h2>四个数字</h2>
+  <div class="card-grid" style="margin-top:22px">
+    <div class="card metric"><div class="value">0</div><div class="label">上游相关 issue</div><p style="margin:.5em 0 0;font-size:.88rem">五个仓库全部搜过，一个都没有。</p></div>
+    <div class="card metric"><div class="value">4</div><div class="label">公开 spec 里的同款 issue</div><p style="margin:.5em 0 0;font-size:.88rem">全部处于 open 状态。</p></div>
+    <div class="card metric"><div class="value">1</div><div class="label">存在但查错属性的护栏</div><p style="margin:.5em 0 0;font-size:.88rem">它问「是不是整数」，而不是「能不能往返」。</p></div>
+    <div class="card metric"><div class="value">~512</div><div class="label">会引爆的取值窗口</div><p style="margin:.5em 0 0;font-size:.88rem">int64 范围最顶端的那几百个值。</p></div>
+  </div>
+</section>
+
+<section class="section">
+  <h2>重新推敲的根因</h2>
+  <p class="lede">此前的说法是「整条链路没有任何一处做等价性检查」。这不准确。检查是存在的。</p>
+
+  <p>codegen 对整数字段的边界确实有守卫：如果边界<strong>不是整数</strong>，直接拒绝。而 2<sup>63</sup> 作为 float64 是一个完完整整的整数，所以它通过审查，一路放行。</p>
+
+  <div class="fig">
+    <svg viewBox="0 0 700 240" role="img" aria-label="护栏检查是否为整数因而放行，而应检查的是能否往返">
+      <defs>
+        <marker id="ga" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+          <path d="M0,0 L10,5 L0,10 z" fill="var(--text-tertiary)"/>
+        </marker>
+      </defs>
+      <g font-family="var(--font-text)" font-size="12.5">
+        <rect x="8" y="94" width="132" height="50" rx="8" fill="var(--bg-secondary)" stroke="var(--border)"/>
+        <text x="74" y="114" text-anchor="middle" fill="var(--text-secondary)" font-size="11.5">取整后的边界</text>
+        <text x="74" y="132" text-anchor="middle" fill="var(--text-primary)" font-family="var(--font-mono)" font-size="12">2^63</text>
+
+        <path d="M140,119 Q176,119 176,58 L212,58" fill="none" stroke="var(--text-tertiary)" stroke-width="1.2" marker-end="url(#ga)"/>
+        <path d="M140,119 Q176,119 176,182 L212,182" fill="none" stroke="var(--text-tertiary)" stroke-width="1.2" marker-end="url(#ga)"/>
+
+        <text x="216" y="26" fill="var(--danger)" font-size="11.5">护栏实际问的</text>
+        <rect x="216" y="34" width="186" height="46" rx="8" fill="var(--bg-secondary)" stroke="var(--danger)"/>
+        <text x="309" y="53" text-anchor="middle" fill="var(--text-primary)" font-size="12">这是不是一个整数？</text>
+        <text x="309" y="70" text-anchor="middle" fill="var(--text-secondary)" font-size="11.5">isIntegral(2^63)</text>
+        <path d="M402,57 L440,57" fill="none" stroke="var(--text-tertiary)" stroke-width="1.2" marker-end="url(#ga)"/>
+        <rect x="444" y="34" width="120" height="46" rx="8" fill="none" stroke="var(--danger)"/>
+        <text x="504" y="53" text-anchor="middle" fill="var(--text-primary)" font-size="12">是</text>
+        <text x="504" y="70" text-anchor="middle" fill="var(--danger)" font-size="12">放行</text>
+        <text x="576" y="61" fill="var(--text-tertiary)" font-size="11.5">bug 出厂</text>
+
+        <text x="216" y="150" fill="var(--success)" font-size="11.5">本该问的</text>
+        <rect x="216" y="158" width="186" height="46" rx="8" fill="var(--bg-secondary)" stroke="var(--success)"/>
+        <text x="309" y="177" text-anchor="middle" fill="var(--text-primary)" font-size="12">它能活着走完一趟吗？</text>
+        <text x="309" y="194" text-anchor="middle" fill="var(--text-secondary)" font-size="11.5">float64(v) 是否仍等于 v</text>
+        <path d="M402,181 L440,181" fill="none" stroke="var(--text-tertiary)" stroke-width="1.2" marker-end="url(#ga)"/>
+        <rect x="444" y="158" width="120" height="46" rx="8" fill="none" stroke="var(--success)"/>
+        <text x="504" y="177" text-anchor="middle" fill="var(--text-primary)" font-size="12">否</text>
+        <text x="504" y="194" text-anchor="middle" fill="var(--success)" font-size="12">拦截</text>
+        <text x="576" y="185" fill="var(--text-tertiary)" font-size="11.5">本可终结</text>
+      </g>
+    </svg>
+  </div>
+  <p class="figcap">同一个值，同一个位置，两个不同的问题。护栏问的那个问题本身是合理的，只是它守的不是这道门。</p>
+
+  <div class="callout">
+    <p style="margin:0;color:var(--text-primary);font-size:1.04rem">所以论点不是「没人检查」，而是 <strong>「有人检查了，检查了错的那个不变量」</strong>。配上 Go 编译器那一拍，全文就有了两道护栏：一道问错了问题，一道问对了问题但够不着那个值。</p>
+  </div>
+
+  <p style="margin-top:18px">同时要澄清一件事：<strong>float64 是结构性的，不是 codegen 的失误。</strong>marker 类型本身就声明为 float64，而目的地是上游 Kubernetes API 类型里的 <span class="mono">Maximum *float64</span>。codegen 无处可放这个数。post 里不能把它写成 codegen 的 bug。</p>
+
+  <div class="callout warn">
+    <p style="margin:0;color:var(--text-primary)">发布前请对着你实际锁定的版本复核那段守卫代码的确切写法。上述结论来自一次上游源码检索，结论可靠，但行号与函数名会随版本漂移。</p>
+  </div>
+</section>
+
+<section class="section">
+  <h2>三层规范的沉默</h2>
+  <p>这个缺陷之所以能一路走到生产，是因为每一层都假设另一层管了这件事。</p>
+
+  <div class="layer">
+    <h3>JSON <span class="pill has">说了</span></h3>
+    <p class="said">RFC 8259 第 6 节：整数落在 <span class="mono">[-(2^53)+1, (2^53)-1]</span> 区间内才「可互操作，各实现会在数值上完全一致」，并建议不要期待超过 IEEE 754 binary64 的精度与范围。</p>
+    <p class="gap">最强的引用来源。规范层面把话说得很清楚。</p>
+  </div>
+
+  <div class="layer">
+    <h3>JSON Schema <span class="pill none">主动免责</span></h3>
+    <p class="said">2020-12 第 6.2.2 节：<span class="mono">maximum</span> 的值必须是一个 number，而不是 integer。第 4.2 节明确表示 JSON Schema 不对精度施加任何边界。</p>
+    <p class="gap">不是遗漏，是声明这不归它管。</p>
+  </div>
+
+  <div class="layer">
+    <h3>OpenAPI <span class="pill open">只字未提</span></h3>
+    <p class="said">3.0.3 把 <span class="mono">int64</span> 定义为「signed 64 bits (a.k.a long)」，对精度限制与 IEEE 754 <strong>完全没有提及</strong>。</p>
+    <p class="gap">这是真正的空白：它承诺了 64 位语义，却把边界字段建立在一个只有 53 位的载体上，而没有对这个矛盾说一个字。</p>
+  </div>
+
+  <div class="layer">
+    <h3>Kubernetes API Conventions <span class="pill has">说了，但在别处</span></h3>
+    <p class="said">「Primitive types」一节写明：所有数字会被 JavaScript 转成 float64，<strong>int64 字段必须做边界检查限制在 <span class="mono">-(2^53) &lt; x &lt; (2^53)</span></strong>，超出的应当以字符串序列化。</p>
+    <p class="gap">但它管的是 Go 字段设计与序列化，字面上从未提及 OpenAPI 的 <span class="mono">maximum</span> 关键字或 marker。引用时必须说明这是外推，不能暗示文档已经覆盖了这个场景。</p>
+  </div>
+
+  <div class="layer">
+    <h3>CRD 文档 / marker 参考 <span class="pill open">完全没有</span></h3>
+    <p class="said">CRD 文档的校验章节、api-concepts 页面、以及 marker 参考手册里，<strong>一个字都没提精度</strong>。</p>
+    <p class="gap">手册甚至没有写明 <span class="mono">Minimum</span> / <span class="mono">Maximum</span> 接收的是 float64：那一栏是空的，而旁边的 <span class="mono">MinItems</span> 写着 <span class="mono">int</span>。使用者根本无从得知自己正在往一个浮点数里塞整数。</p>
+  </div>
+
+  <div class="callout danger">
+    <p style="margin:0;color:var(--text-primary)">链条是完整的：JSON 说清楚了 → JSON Schema 声明不管 → <strong>OpenAPI 沉默</strong> → Kubernetes 在一份讲 Go 字段的文档里说了 → 面向使用者的 marker 文档一字未提。<strong>规范说过的话，没能走到写 marker 的人面前。</strong></p>
+  </div>
+</section>
+
+<section class="section">
+  <h2>上游：没有人报过</h2>
+  <p>五个仓库，围绕 precision、rounding、int64、float64 以及字面量 <span class="mono">9223372036854775807</span> 检索。</p>
+  <table class="tbl" style="margin-top:16px">
+    <thead><tr><th>仓库</th><th>结果</th></tr></thead>
+    <tbody>
+      <tr><td>controller-tools</td><td class="no">无</td></tr>
+      <tr><td>kubernetes/kubernetes</td><td class="no">无</td></tr>
+      <tr><td>apiextensions-apiserver</td><td class="no">无</td></tr>
+      <tr><td>kube-openapi</td><td class="no">无</td></tr>
+      <tr><td>go-openapi/validate</td><td class="no">无</td></tr>
+    </tbody>
+  </table>
+  <p style="margin-top:16px">最接近的历史近亲是一个 2017 年已关闭的 issue：ThirdPartyResource 里的大数字返回成了科学计数法。同样的 float64 根因，但它讲的是<strong>实例数据</strong>，不是<strong>schema 边界</strong>，而且是靠保留整数的 JSON 反序列化修掉的。不能当成同一个 bug 引用。</p>
+  <div class="callout">
+    <p style="margin:0;color:var(--text-primary)">这是一个机会，而且它改变了这篇 post 能是什么。<strong>记录陷阱的 post 有用；记录陷阱、顺手提出第一个上游 issue、并在文末链接它的 post，是一份贡献。</strong></p>
+  </div>
+</section>
+
+<section class="section">
+  <h2>但它活在公开 spec 里</h2>
+  <p>「别人是不是也中招了」这个问题的实证答案。数字一模一样。</p>
+  <table class="tbl" style="margin-top:16px">
+    <thead><tr><th>项目</th><th>状态</th><th>内容</th></tr></thead>
+    <tbody>
+      <tr><td>openai/openai-openapi<br><span style="color:var(--text-tertiary);font-size:.86rem">#360 · #464 · #549</span></td><td><span class="pill open">三个全 open</span></td><td><span class="mono">seed</span> 字段上 <span class="mono">maximum: 9223372036854776000</span>。其中一个 issue 把成因诊断得分毫不差：生成 YAML 的管线某处把大整数当成了浮点数。</td></tr>
+      <tr><td>weaviate<br><span style="color:var(--text-tertiary);font-size:.86rem">#11735</span></td><td><span class="pill open">open</span></td><td>「int64 边界值 9223372036854775807 被静默截断为 9223372036854776000」。</td></tr>
+    </tbody>
+  </table>
+  <div class="callout warn">
+    <p style="margin:0;color:var(--text-primary)">诚实边界：同样的 2<sup>63</sup> 边界也出现在若干 CRD 派生的 JSON schema 里，但其中一个项目的<strong>源 CRD 根本没写 <span class="mono">maximum</span></strong>。那些边界是下游的 CRD 转 JSON Schema 工具注入的。同类缺陷，不同生产者，<strong>不能当成 codegen 的产物呈现</strong>。</p>
+  </div>
+  <p style="margin-top:16px">重点在于 venue 比 CRD 更宽：这是一个 <strong>OpenAPI 全域的缺陷类</strong>，任何把整数边界塞进 float64 的工具链都会中招。这也正好是把读者从「Kubernetes operator 作者」扩展到「所有写 API 的人」的那把钥匙。</p>
+</section>
+
+<section class="section">
+  <h2>为什么它没有被大规模发现</h2>
+  <p>架构分歧要求取整后的值<strong>跳出</strong> int64 范围。实测下来，那个窗口窄得出奇。</p>
+  <table class="tbl" style="margin-top:16px">
+    <thead><tr><th>marker 写的值</th><th>取整后</th><th>精确</th><th>跳出 int64</th></tr></thead>
+    <tbody>
+      <tr><td>2<sup>53</sup> − 1</td><td class="mono">9007199254740991</td><td class="yes">是</td><td>否</td></tr>
+      <tr><td>5 × 10<sup>18</sup></td><td class="mono">5000000000000000000</td><td class="yes">是</td><td>否</td></tr>
+      <tr><td>2<sup>62</sup></td><td class="mono">4611686018427387904</td><td class="yes">是</td><td>否</td></tr>
+      <tr><td>MaxInt64 − 512</td><td class="mono">9223372036854774784</td><td class="no">否</td><td>否</td></tr>
+      <tr><td><strong>MaxInt64</strong></td><td class="mono">9223372036854775808</td><td class="no">否</td><td class="no"><strong>是</strong></td></tr>
+    </tbody>
+  </table>
+  <p style="margin-top:16px">所以有两种失效模式，只有第二种跟架构有关。2<sup>53</sup> 到 2<sup>63</sup> 之间，边界被悄悄近似但仍在 int64 内，实际上限略有偏差而无人在意。只有在 <strong>int64 范围最顶端的几百个值</strong>里，取整后的边界才会跳出去。</p>
+  <div class="callout">
+    <p style="margin:0;color:var(--text-primary);font-size:1.04rem">而 MaxInt64 恰恰是一个认真的人，在 lint 规则要求「必须写 Maximum」、而这个字段又没有真实上限时，<strong>会伸手去拿的那个值</strong>。<br><br>你为了表达「没有上限」而选中的那一个数，是整个范围里唯一会引爆的数。</p>
+  </div>
+  <p style="margin-top:16px">还有一层不对称值得写进去：同一个「无实际上限」的习惯用法，在 32 位上是 <span class="mono">2147483647</span>，<strong>完全安全</strong>，因为 MaxInt32 远低于 2<sup>53</sup>，穿过 float64 毫发无损。这个习惯平移到 64 位就静默失效了。不是有人写错了，而是<strong>一个正确的习惯换了个位宽</strong>。</p>
+</section>
+
+<section class="section">
+  <h2>这篇 post 因此可以是什么</h2>
+  <p class="lede">把以上叠起来，定位应该往上调一档。</p>
+  <div class="callout">
+    <p style="margin:0;color:var(--text-primary);font-size:1.05rem">这不是「我踩了个坑」。这是<strong>一个 OpenAPI 全域的缺陷类，活在公开 spec 里，规范没写，上游没人报过，而现有的那道护栏检查了错的属性</strong>。</p>
+  </div>
+  <p>四个可执行的推论：</p>
+  <p><strong>一，扩大读者。</strong>冷开场之后一句话把非 Kubernetes 读者留下来，用已被证实的 Twitter <span class="mono">id_str</span> 先例。Discord 不能照「同样原因」引用，他们给出的理由是防止整数溢出，从未提及 53 位。</p>
+  <p><strong>二，重构论点。</strong>围绕两道护栏来写：一道问错了问题，一道问对了问题但够不着。这比「没人检查」强一档。</p>
+  <p><strong>三，提一个上游 issue。</strong>发布前做，文末链接它。这是全文最便宜也最重的一笔。</p>
+  <p><strong>四，脚注引 RFC 8259 第 6 节</strong>，并点名 OpenAPI 的沉默是规范空白。</p>
+</section>
+
+</main>
+<script>
+const root = document.documentElement;
+const saved = localStorage.getItem('paint-theme');
+if (saved) root.dataset.theme = saved;
+if (root.dataset.theme === 'auto')
+  root.dataset.theme = matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+const SUN = '<svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="4"/><path d="M12 2v2M12 20v2M4.9 4.9l1.4 1.4M17.7 17.7l1.4 1.4M2 12h2M20 12h2M4.9 19.1l1.4-1.4M17.7 6.3l1.4-1.4"/></svg>';
+const MOON = '<svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M21 12.8A9 9 0 1111.2 3 7 7 0 0021 12.8z"/></svg>';
+const btn = document.getElementById('theme-toggle');
+const paintIcon = () => btn.innerHTML = root.dataset.theme === 'dark' ? SUN : MOON;
+paintIcon();
+btn.addEventListener('click', () => {
+  root.dataset.theme = root.dataset.theme === 'dark' ? 'light' : 'dark';
+  localStorage.setItem('paint-theme', root.dataset.theme);
+  paintIcon();
+});
+if (root.dataset.anim !== 'off') {
+  const io = new IntersectionObserver((es) => es.forEach(e => {
+    if (e.isIntersecting) { e.target.classList.add('visible'); io.unobserve(e.target); }
+  }), { threshold: .12 });
+  document.querySelectorAll('.reveal').forEach(el => io.observe(el));
+} else {
+  document.querySelectorAll('.reveal').forEach(el => el.classList.add('visible'));
+}
+</script>
+</body>
+</html>


### PR DESCRIPTION
## Summary

Research and drafting material for an upcoming post about an integer bound that inverted itself between a Go marker and the apiserver. A `Maximum` set to MaxInt64 was emitted into the generated schema as 2^63, and narrowing that value back to an int64 is left implementation-dependent by the Go spec, so it validated correctly on ARM and rejected every write on x86.

Adds eight files under `.planning/post-material/`: a drafting outline with per-section word budgets, the source material, a style guide extracted from the published posts, a pre-drafting review, and three self-contained HTML explainers covering how the bug happened, how to structure the post, and why it is worth writing.

The `.gitignore` change is load-bearing and not obvious. The global `core.excludesFile` ignores `.planning/` as a directory, and git never descends into an excluded directory, so an exception alone is a no-op. The directory is re-included first, its contents re-ignored, then `post-material` excepted. Everything else under `.planning/` stays ignored and the 23 already-tracked files there are unaffected.

No site content, application code, or build files are touched.

## Testing Done

- [x] Local code review completed
- [x] Verified the ignore rule against `git status` rather than `git check-ignore`, which misreports for tracked paths: exactly 8 untracked files appear under `.planning/`, and `tmp`, `research`, `phases`, `STATE.md`, `ROADMAP.md` all remain ignored
- [x] Confirmed the 23 previously tracked `.planning/` files are unchanged
- [x] Scanned the diff for credentials and for internal identifiers; no hits
- [x] Confirmed all three HTML files are self-contained with zero external requests, so they render offline