### PR TITLE
docs(content): replace the dead Arm link and add a description

### DIFF
--- a/src/content/preview/the-maximum-became-the-minimum.mdx
+++ b/src/content/preview/the-maximum-became-the-minimum.mdx
@@ -1,6 +1,7 @@
 ---
 title: 'The Maximum Became the Minimum'
 date: '2026-07-26'
+description: 'A CRD maximum of MaxInt64 rounded up through float64 to exactly 2^63. Narrowing it back to int64 saturated on ARM and inverted to MinInt64 on x86.'
 tags: ['kubernetes', 'openapi', 'floating-point']
 category: 'engineering'
 location: 'Palo Alto, CA'
@@ -106,7 +107,7 @@ The compiler knew. It just never got to see the number.
 
 [^5]: The Go [conversion specification](https://go.dev/ref/spec#Conversions) makes an unrepresentable runtime result implementation-dependent and rejects overflowing constants.
 
-[^6]: `go tool compile -S` emits `FCVTZSD` on arm64 and `CVTTSD2SQ` on amd64, with no range check either side; the [repro](https://github.com/initor/blog-nextjs/tree/master/public/repro/the-maximum-became-the-minimum) carries the disassembly. Arm's [`FPToFixed`](https://developer.arm.com/documentation/ddi0602/latest/Shared-Pseudocode/AArch64-Functions/Shared-Floating-point-functions?lang=en#func_FPToFixed_7) generates a saturated result; x86 [`CVTTSD2SI`](https://www.felixcloutier.com/x86/cvttsd2si) returns the integer indefinite value when the invalid exception is masked.
+[^6]: `go tool compile -S` emits `FCVTZSD` on arm64 and `CVTTSD2SQ` on amd64, with no range check either side; the [repro](https://github.com/initor/blog-nextjs/tree/master/public/repro/the-maximum-became-the-minimum) carries the disassembly and both results. Arm's `FPToFixed` pseudocode, in the A-profile Architecture Reference Manual (DDI 0487), generates a saturated result; x86 [`CVTTSD2SI`](https://www.felixcloutier.com/x86/cvttsd2si) returns the integer indefinite value when the invalid exception is masked.
 
 [^7]: Controller-tools checks only [integrality](https://github.com/kubernetes-sigs/controller-tools/blob/41fba8525412a0a09a6df3014b9a7f88650584b3/pkg/crd/markers/validation.go#L703-L704) before storing the bound unmodified.
 


### PR DESCRIPTION
## Summary
The Arm citation in `[^6]` pointed at a URL that serves a login wall rather than the `FPToFixed` pseudocode it claims to support. Replaces it with a named source plus the repro's own evidence, and adds the frontmatter `description` the post needs before it leaves `preview/`.

## Details
- `[^6]` now names Arm's `FPToFixed` pseudocode in the A-profile Architecture Reference Manual (DDI 0487) rather than deep-linking it, because no path on `developer.arm.com` is readable without an Arm ID. The saturation claim rests on the repro, which executes the conversion on Arm silicon and carries the disassembly.
- `description` added to frontmatter. It populates the dek and the `og:`/`twitter:` descriptions today, and the Atom `<summary>` and JSON-LD description on promotion to `blog/`.

## Testing Done
- [x] 87 unit tests pass, production build compiles
- [x] All 13 links in the post return 200; the dead one is gone
- [x] Verified in headless Chrome that no `developer.arm.com` path is citable. The original URL, the DDI 0487 landing page and the FCVTZS instruction page each render roughly 1KB of "Log in with your Arm ID" and contain no `FPToFixed`, no `FCVTZS` and no saturation text. Alternatives also failed: Stanford's ISA-XML mirror does not resolve, `dougallj`'s list covers only the SVE mnemonic, and Arm's PDF service 404s.
- [x] Confirmed the description reaches `meta`, `og:description`, `twitter:description` and the visible dek. JSON-LD is not emitted on `/preview/` by design, and the `/blog/` route builds it from the same field.

## Known gaps
One review item is still open and needs author input: the sentence explaining why capping the marker below 2^53 was not acceptable. Everything else from the two fresh-eye reviews is now addressed.
