### PR TITLE
fix(diagrams): make every diagram readable in the prose column

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -252,9 +252,8 @@ html {
     margin-bottom: 0;
   }
 
-  /* ContextFlow + SessionBridge — Apple-style visualization containers */
-  .cf,
-  .sb {
+  /* ContextFlow — Apple-style visualization container */
+  .cf {
     margin: 1.5em 0 0;
     background: #f5f5f7;
     border: 1px solid #d2d2d7;
@@ -262,14 +261,12 @@ html {
     padding: 1.25em 0.75em 0.75em;
   }
 
-  .cf-header,
-  .sb-header {
+  .cf-header {
     text-align: center;
     margin-bottom: 0.25em;
   }
 
-  .cf-title,
-  .sb-title {
+  .cf-title {
     display: block;
     font-family: var(--font-heading), system-ui, sans-serif;
     font-size: 0.95rem;
@@ -278,8 +275,7 @@ html {
     color: #1d1d1f;
   }
 
-  .cf-subtitle,
-  .sb-subtitle {
+  .cf-subtitle {
     display: block;
     font-family: var(--font-heading), system-ui, sans-serif;
     font-size: 0.78rem;
@@ -288,11 +284,216 @@ html {
     margin-top: 0.15em;
   }
 
-  .cf-svg,
-  .sb-svg {
+  .cf-svg {
     display: block;
     width: 100%;
     height: auto;
+  }
+
+  /* SessionBridge
+     HTML and CSS rather than a fixed viewBox, for the reason in the component
+     header: viewBox units scale with the container, so the old SVG rendered its
+     labels at 4px on a phone. Every size below is in rem and never scales.
+
+     Colours come from the shared tokens rather than the Apple palette the SVG
+     hardcoded, so this follows the site into dark mode instead of staying a
+     light island, and the ephemeral cards are actually dashed, which the old
+     component's own header claimed but its code did not do. */
+  .sb {
+    margin: 1.5em 0;
+    padding: 0;
+    border-radius: 0.75rem;
+    border: 1px solid var(--code-border);
+    background: var(--code-bg);
+    overflow: hidden;
+  }
+
+  .sb-header {
+    padding: 0.75rem 1.25rem;
+    border-bottom: 1px solid var(--code-border);
+    display: flex;
+    flex-direction: column;
+    gap: 0.15rem;
+  }
+
+  .sb-title {
+    font-family: var(--font-heading), system-ui, sans-serif;
+    font-weight: 600;
+    font-size: 0.85rem;
+    color: var(--code-fg);
+  }
+
+  .sb-subtitle {
+    font-family: var(--font-mono), ui-monospace, monospace;
+    font-size: 0.7rem;
+    color: var(--code-comment);
+  }
+
+  /* Roughly the old 160 / 120 / 160 proportions, but as fractions so the cards
+     share whatever width the column has instead of a fixed coordinate space. */
+  .sb-body {
+    display: grid;
+    grid-template-columns: 1fr auto 0.85fr auto 1fr;
+    align-items: stretch;
+    gap: 0.4rem;
+    padding: 1rem 0.9rem;
+  }
+
+  .sb-session,
+  .sb-bridge {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 0.35rem;
+    padding: 0.6rem 0.5rem;
+    border-radius: 0.5rem;
+    text-align: center;
+  }
+
+  .sb-session {
+    border: 1px dashed color-mix(in srgb, var(--code-comment) 60%, transparent);
+    background: color-mix(in srgb, var(--code-border) 22%, transparent);
+  }
+
+  .sb-bridge {
+    border: 1.5px solid var(--code-title);
+    background: color-mix(in srgb, var(--code-title) 12%, var(--code-bg));
+  }
+
+  .sb-session-name {
+    font-family: var(--font-heading), system-ui, sans-serif;
+    font-size: 0.8rem;
+    font-weight: 600;
+    letter-spacing: -0.01em;
+    color: var(--code-fg);
+  }
+
+  .sb-session-sub {
+    font-family: var(--font-mono), ui-monospace, monospace;
+    font-size: 0.75rem;
+    color: var(--code-comment);
+  }
+
+  .sb-tasks,
+  .sb-files {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 0.3rem;
+    width: 100%;
+  }
+
+  .sb-task {
+    font-family: var(--font-heading), system-ui, sans-serif;
+    font-size: 0.75rem;
+    font-weight: 500;
+    color: var(--code-title);
+    background: color-mix(in srgb, var(--code-title) 12%, var(--code-bg));
+    border: 1px solid color-mix(in srgb, var(--code-title) 35%, transparent);
+    border-radius: 0.35rem;
+    padding: 0.3rem 0.35rem;
+  }
+
+  .sb-bridge-head {
+    font-family: var(--font-mono), ui-monospace, monospace;
+    font-size: 0.78rem;
+    font-weight: 600;
+    color: var(--code-title);
+    width: 100%;
+    padding-bottom: 0.3rem;
+    border-bottom: 1px solid color-mix(in srgb, var(--code-title) 25%, transparent);
+  }
+
+  .sb-file {
+    font-family: var(--font-mono), ui-monospace, monospace;
+    font-size: 0.75rem;
+    font-weight: 500;
+    color: var(--code-title);
+    background: var(--code-bg);
+    border: 1px solid color-mix(in srgb, var(--code-title) 30%, transparent);
+    border-radius: 0.35rem;
+    padding: 0.25rem 0.3rem;
+  }
+
+  .sb-tag {
+    font-family: var(--font-heading), system-ui, sans-serif;
+    font-size: 0.75rem;
+    color: var(--code-comment);
+    margin-top: auto;
+  }
+
+  .sb-tag-persistent {
+    color: var(--code-title);
+    font-weight: 500;
+  }
+
+  /* Drawn in CSS so it inherits currentColor and has no coordinate system. */
+  .sb-arrow {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    gap: 0.25rem;
+    min-width: 2.75rem;
+    color: var(--code-title);
+  }
+
+  .sb-arrow-label {
+    font-family: var(--font-heading), system-ui, sans-serif;
+    font-size: 0.75rem;
+    font-weight: 500;
+  }
+
+  .sb-arrow-line {
+    position: relative;
+    display: block;
+    width: 100%;
+    max-width: 2rem;
+    height: 1px;
+    background: currentColor;
+    opacity: 0.6;
+  }
+
+  .sb-arrow-line::after {
+    content: '';
+    position: absolute;
+    right: 0;
+    top: 50%;
+    width: 5px;
+    height: 5px;
+    border-top: 1.5px solid currentColor;
+    border-right: 1.5px solid currentColor;
+    transform: translate(1px, -50%) rotate(45deg);
+  }
+
+  /* Stack below the prose breakpoint. Nothing shrinks; the cards just get the
+     full column each, which is what keeps the type at source size. */
+  @media (max-width: 640px) {
+    .sb-body {
+      grid-template-columns: 1fr;
+      gap: 0;
+      padding: 0.75rem 0.6rem;
+    }
+
+    .sb-arrow {
+      padding: 0.5rem 0;
+      min-width: 0;
+    }
+
+    .sb-arrow-line {
+      width: 1px;
+      max-width: none;
+      height: 1.4rem;
+    }
+
+    .sb-arrow-line::after {
+      right: 50%;
+      top: auto;
+      bottom: 0;
+      transform: translate(50%, 1px) rotate(135deg);
+    }
   }
 
   /* Callout — pull-quote component */
@@ -2313,24 +2514,30 @@ sup {
 }
 
 /* Mermaid diagram sizing
-   Mermaid is initialized with sequence.useMaxWidth:false so the SVG keeps its
-   intrinsic width. Without that it emits width="100%" and silently shrinks the
-   diagram to the prose column (measured: 3.6px message text at 375px), which the
-   wrapper's overflow-x-auto cannot rescue because there is nothing to overflow.
+   Diagrams sit in the prose column, at the same width as paragraphs, code blocks
+   and every hand-authored diagram component. Mermaid used to break out to
+   1200px against a 640px column, which made it the only element on the page that
+   did not line up.
 
-   Sequence diagrams are wider than the 640px prose column, so the wrapper breaks
-   out symmetrically around the column, capped at 1200px and at the viewport. The
-   clamp means no media query is needed: wide screens fit the whole diagram at
-   source size, narrow screens fall back to real horizontal scrolling.
+   The SVG scales into that column rather than overflowing it: mermaid emits
+   width="100%" with a max-width of the diagram's source width, and height:auto
+   keeps the aspect ratio instead of letterboxing it. What keeps the scaled-down
+   text readable is Mermaid.tsx, which picks the widest layout preset that fits
+   the column. Sizing alone cannot do it, because the widest diagram is 1191px at
+   source and lands at 5.5px text when squeezed into a phone column.
 
-   margin-inline: auto on the SVG centers it when it fits and resolves to 0 when
-   it overflows, so the scroll always starts at the diagram's left edge. */
+   max-width caps upscaling, so a diagram narrower than the column stays at
+   source size and centres rather than being blown up past the body text size.
+
+   overflow-x is a backstop only. Every diagram is measured at 320px and up and
+   none of them reach for it. */
 .mermaid-diagram {
-  width: min(1200px, calc(100vw - 4rem));
-  margin-left: calc((100% - min(1200px, calc(100vw - 4rem))) / 2);
+  overflow-x: auto;
 }
 
 .mermaid-diagram svg {
   display: block;
+  width: 100%;
+  height: auto;
   margin-inline: auto;
 }

--- a/src/components/mdx/Mermaid.test.tsx
+++ b/src/components/mdx/Mermaid.test.tsx
@@ -1,0 +1,213 @@
+import {
+  intrinsicWidthOf,
+  fitsColumn,
+  hasInventedHyphen,
+  pickLayout,
+  explainLayouts,
+} from '@/components/mdx/Mermaid';
+
+describe('intrinsicWidthOf', () => {
+  it('reads the width out of a real mermaid viewBox with a negative origin', () => {
+    const svg = '<svg id="x" width="100%" viewBox="-50 -10 1191 694" style="max-width: 1191px;">';
+    expect(intrinsicWidthOf(svg)).toBe(1191);
+  });
+
+  it('reads fractional widths', () => {
+    expect(intrinsicWidthOf('<svg viewBox="-103 -10 939.5 635">')).toBe(939.5);
+  });
+
+  it('tolerates comma separators and leading whitespace', () => {
+    expect(intrinsicWidthOf('<svg viewBox=" 0,0,420,300">')).toBe(420);
+  });
+
+  it('is unaffected by a width attribute of "100%"', () => {
+    // useMaxWidth makes width="100%", so the viewBox is the only real source.
+    expect(intrinsicWidthOf('<svg width="100%" viewBox="0 0 598 889">')).toBe(598);
+  });
+
+  it('returns null when there is no viewBox to measure', () => {
+    expect(intrinsicWidthOf('<svg width="600" height="400">')).toBeNull();
+  });
+
+  it('returns null for a degenerate zero width', () => {
+    expect(intrinsicWidthOf('<svg viewBox="0 0 0 0">')).toBeNull();
+  });
+});
+
+describe('fitsColumn', () => {
+  it('accepts a diagram narrower than the column', () => {
+    expect(fitsColumn(275, 326)).toBe(true);
+  });
+
+  it('rejects a diagram meaningfully wider than the column', () => {
+    expect(fitsColumn(1191, 326)).toBe(false);
+  });
+
+  it('accepts a 2% overshoot rather than dropping a whole preset over a rounding error', () => {
+    expect(fitsColumn(650, 640)).toBe(true);
+  });
+
+  it('rejects an overshoot beyond the tolerance', () => {
+    expect(fitsColumn(700, 640)).toBe(false);
+  });
+
+  it('treats an unmeasured column as fitting, so a hidden container still renders', () => {
+    expect(fitsColumn(1191, 0)).toBe(true);
+  });
+});
+
+describe('hasInventedHyphen', () => {
+  // Mermaid emits one <text> per wrapped line, all sharing a class. This mirrors
+  // the real output; a fixture built from sibling tspans would pass a detector
+  // that never fires on the real thing.
+  const svgWith = (...lines: string[]) =>
+    `<svg xmlns="http://www.w3.org/2000/svg">${lines
+      .map((l) => `<text class="messageText"><tspan>${l}</tspan></text>`)
+      .join('')}</svg>`;
+
+  const CHART = [
+    'sequenceDiagram',
+    '    participant G as controller-tools',
+    '    participant V as kube-openapi',
+    '    M->>G: Maximum = 9223372036854775807',
+    '    V->>V: Return 0x8000000000000000',
+  ].join('\n');
+
+  it('flags a hyphen mermaid invented inside a number', () => {
+    // This is the case that made the post render its own subject wrong.
+    expect(hasInventedHyphen(svgWith('9223372036854-', '775807'), CHART)).toBe(true);
+  });
+
+  it('flags a second hyphen appended next to one the author wrote', () => {
+    expect(hasInventedHyphen(svgWith('controller--', 'tools'), CHART)).toBe(true);
+  });
+
+  it('flags a hyphen invented inside a word', () => {
+    expect(hasInventedHyphen(svgWith('kube-open-', 'api'), CHART)).toBe(true);
+  });
+
+  it("allows a break at a hyphen the author wrote", () => {
+    expect(hasInventedHyphen(svgWith('controller-', 'tools'), CHART)).toBe(false);
+  });
+
+  it('ignores wrapping that does not introduce a hyphen at all', () => {
+    expect(hasInventedHyphen(svgWith('Maximum =', '9223372036854775807'), CHART)).toBe(false);
+  });
+
+  it('ignores a trailing hyphen on the last line, which broke nothing', () => {
+    expect(hasInventedHyphen(svgWith('Return 0x8000000000000000-'), CHART)).toBe(false);
+  });
+
+  it('does not rejoin two lines belonging to different labels', () => {
+    const svg =
+      '<svg xmlns="http://www.w3.org/2000/svg">' +
+      '<text class="actor"><tspan>kube-open-</tspan></text>' +
+      '<text class="messageText"><tspan>api</tspan></text></svg>';
+    expect(hasInventedHyphen(svg, CHART)).toBe(false);
+  });
+
+  it('does not flag a split it cannot prove was invented', () => {
+    expect(hasInventedHyphen(svgWith('some-', 'thing'), CHART)).toBe(false);
+  });
+
+  it('tolerates unparseable input rather than rejecting every layout', () => {
+    expect(hasInventedHyphen('not svg at all', CHART)).toBe(false);
+  });
+});
+
+describe('pickLayout', () => {
+  const svgOf = (w: number, ...lines: string[]) =>
+    `<svg xmlns="http://www.w3.org/2000/svg" width="100%" viewBox="0 0 ${w} 400">` +
+    lines.map((l) => `<text class="messageText"><tspan>${l}</tspan></text>`).join('') +
+    '</svg>';
+
+  const CHART = 'sequenceDiagram\n    M->>G: Maximum = 9223372036854775807';
+
+  // Widths mirror the real ladder for the-maximum-became-the-minimum.
+  const LADDER = [1096, 800, 739, 651, 558, 484, 422];
+  const clean = (i: number) => svgOf(LADDER[i], 'Maximum =', '9223372036854775807');
+  // Presets from index 4 down corrupt the literal, exactly as measured.
+  const maybeBroken = (i: number) =>
+    i >= 4 ? svgOf(LADDER[i], '9223372036854-', '775807') : clean(i);
+
+  it('picks the widest preset that fits, not the first one rendered', async () => {
+    const out = await pickLayout(700, CHART, async (i) => clean(i));
+    expect(intrinsicWidthOf(out!)).toBe(651);
+  });
+
+  it('stops rendering as soon as a preset fits', async () => {
+    const seen: number[] = [];
+    await pickLayout(1200, CHART, async (i) => {
+      seen.push(i);
+      return clean(i);
+    });
+    expect(seen).toEqual([0]);
+  });
+
+  it('refuses a narrower preset that would corrupt a token', async () => {
+    // 484 and 422 both fit a 326px column better, but both hyphenate the number.
+    const out = await pickLayout(326, CHART, async (i) => maybeBroken(i));
+    expect(intrinsicWidthOf(out!)).toBe(651);
+  });
+
+  it('uses a narrow preset when it corrupts nothing', async () => {
+    const out = await pickLayout(326, CHART, async (i) => clean(i));
+    expect(intrinsicWidthOf(out!)).toBe(422);
+  });
+
+  it('falls back to a corrupting preset only when every preset corrupts', async () => {
+    const out = await pickLayout(326, CHART, async (i) =>
+      svgOf(LADDER[i], '9223372036854-', '775807')
+    );
+    expect(intrinsicWidthOf(out!)).toBe(422);
+  });
+
+  it('skips a preset mermaid rejects and keeps going', async () => {
+    const out = await pickLayout(760, CHART, async (i) => {
+      if (i === 2) throw new Error('mermaid blew up on this preset');
+      return clean(i);
+    });
+    expect(intrinsicWidthOf(out!)).toBe(651);
+  });
+
+  it('returns null only when every preset fails', async () => {
+    const out = await pickLayout(640, CHART, async () => {
+      throw new Error('nope');
+    });
+    expect(out).toBeNull();
+  });
+
+  it('takes an unmeasurable render as-is instead of discarding it', async () => {
+    const bare = '<svg xmlns="http://www.w3.org/2000/svg" width="600" height="400"></svg>';
+    const out = await pickLayout(640, CHART, async () => bare);
+    expect(out).toBe(bare);
+  });
+});
+
+describe('explainLayouts', () => {
+  const CHART = 'sequenceDiagram\n    M->>G: Maximum = 9223372036854775807';
+  const svgOf = (w: number, ...lines: string[]) =>
+    `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 ${w} 400">` +
+    lines.map((l) => `<text class="messageText"><tspan>${l}</tspan></text>`).join('') +
+    '</svg>';
+
+  it('reports width and cleanliness for every preset, for diagnosis', async () => {
+    const rows = await explainLayouts(CHART, async (i) =>
+      i < 2
+        ? svgOf(1000 - i * 100, '9223372036854775807')
+        : svgOf(1000 - i * 100, '9223372036854-', '775807')
+    );
+    expect(rows).toHaveLength(7);
+    expect(rows[0]).toEqual({ name: 'source', width: 1000, clean: true });
+    expect(rows[1].clean).toBe(true);
+    expect(rows.slice(2).every((r) => r.clean === false)).toBe(true);
+  });
+
+  it('marks a preset mermaid rejected rather than dropping the row', async () => {
+    const rows = await explainLayouts(CHART, async () => {
+      throw new Error('nope');
+    });
+    expect(rows).toHaveLength(7);
+    expect(rows.every((r) => r.width === null && r.clean === false)).toBe(true);
+  });
+});

--- a/src/components/mdx/Mermaid.tsx
+++ b/src/components/mdx/Mermaid.tsx
@@ -11,15 +11,218 @@ function getCSSVar(name: string): string {
   return getComputedStyle(document.documentElement).getPropertyValue(name).trim();
 }
 
+/* Responsive sizing
+   ------------------
+   A sequence diagram has an intrinsic width set by its participants and labels.
+   The maximum post is 1191px wide against a 326px column on a 390px phone, so
+   neither obvious strategy works alone: scaling it to fit puts the text at
+   5.5px, and pinning it to source size hides 73% of it behind a horizontal
+   scroll.
+
+   Tightening spacing barely helps, because width is dominated by label text and
+   not by gaps: with wrapping off, the widest diagram only comes down from 1096px
+   to 854px. Wrapping is what actually collapses it, to 379px. But mermaid wraps
+   by hard-breaking mid-token and inserting a hyphen, which turned
+   9223372036854775807 into "922337203685-4775807" in a post whose whole subject
+   is that exact integer. Zooming can fix text that is too small; it cannot
+   un-hyphenate a number.
+
+   So we wrap, but only as far as the text allows. Each preset below caps the
+   wrap width; a preset is discarded outright if it made mermaid invent a hyphen
+   inside a token. Among the survivors we take the widest that fits the column,
+   or the narrowest overall when none fit, which is the largest on-screen text
+   the diagram can reach without corrupting its own labels. Where that floor
+   lands is a property of the chart: charts with short labels reach 20px on a
+   phone, and the maximum post bottoms out around 10px because it contains four
+   unbreakable 18-to-19 character literals. */
+
+/** Sequence layout presets, widest first. `width` caps how far text may wrap. */
+const LAYOUTS: ReadonlyArray<{ name: string; sequence: Record<string, unknown> }> = [
+  { name: 'source', sequence: {} },
+  { name: 'w190', sequence: { width: 190, actorMargin: 24, boxMargin: 10, noteMargin: 10, messageMargin: 32, diagramMarginX: 20, wrap: true } },
+  { name: 'w165', sequence: { width: 165, actorMargin: 18, boxMargin: 8, noteMargin: 8, messageMargin: 28, diagramMarginX: 16, wrap: true } },
+  { name: 'w145', sequence: { width: 145, actorMargin: 12, boxMargin: 8, noteMargin: 8, messageMargin: 26, diagramMarginX: 12, wrap: true } },
+  { name: 'w125', sequence: { width: 125, actorMargin: 8, boxMargin: 6, noteMargin: 6, messageMargin: 24, diagramMarginX: 10, wrap: true } },
+  { name: 'w105', sequence: { width: 105, actorMargin: 5, boxMargin: 5, noteMargin: 5, messageMargin: 22, diagramMarginX: 8, wrap: true } },
+  { name: 'w90', sequence: { width: 90, actorMargin: 3, boxMargin: 4, noteMargin: 4, messageMargin: 20, diagramMarginX: 6, wrap: true } },
+];
+
+/** How far a preset may exceed the column and still count as fitting. Two percent
+ *  costs two percent of text size, and avoids discarding a well-proportioned
+ *  layout in favour of a much tighter one over a rounding error. */
+const FIT_TOLERANCE = 1.02;
+
+/** Intrinsic width of a rendered diagram, read from its viewBox. Mermaid always
+ *  emits one, and it is authoritative even when width is the string "100%". */
+export function intrinsicWidthOf(svg: string): number | null {
+  const m = svg.match(/viewBox="\s*([-\d.]+)[ ,]+([-\d.]+)[ ,]+([\d.]+)[ ,]+([\d.]+)/);
+  if (!m) return null;
+  const w = Number.parseFloat(m[3]);
+  return Number.isFinite(w) && w > 0 ? w : null;
+}
+
+/** Whether a diagram of this intrinsic width renders in this column unscaled. */
+export function fitsColumn(intrinsicWidth: number, columnWidth: number): boolean {
+  if (columnWidth <= 0) return true;
+  return intrinsicWidth <= columnWidth * FIT_TOLERANCE;
+}
+
+/**
+ * Whether mermaid split a token by inventing a hyphen that is not in the source.
+ *
+ * Wrapping at a hyphen the author wrote is fine: "controller-" / "tools" reads
+ * correctly. Wrapping mid-token is not: "9223372036854-" / "775807" reads as a
+ * different number. The two are told apart by rejoining the pair and asking
+ * which form the chart actually contains. Only a provably invented hyphen
+ * counts, so an unrecognised split never costs us a usable layout.
+ *
+ * Note that mermaid emits each wrapped line as its own <text> element rather
+ * than as sibling <tspan>s, so the comparison has to be across elements in
+ * document order. Looking inside a single <text> finds nothing.
+ */
+export function hasInventedHyphen(svg: string, chart: string): boolean {
+  if (typeof DOMParser === 'undefined') return false;
+
+  let doc: Document;
+  try {
+    doc = new DOMParser().parseFromString(svg, 'image/svg+xml');
+  } catch {
+    return false;
+  }
+
+  const source = chart.replace(/\s+/g, '');
+  const squash = (s: string) => s.replace(/\s+/g, '');
+
+  // One entry per rendered line, in document order, tagged with its owner so we
+  // never rejoin two labels that merely happen to be adjacent.
+  const lines: Array<{ text: string; group: string }> = [];
+  for (const el of Array.from(doc.querySelectorAll('text'))) {
+    const group = el.getAttribute('class') ?? '';
+    const spans = Array.from(el.querySelectorAll('tspan'));
+    if (spans.length > 1) {
+      for (const s of spans) {
+        const t = (s.textContent ?? '').trim();
+        if (t) lines.push({ text: t, group });
+      }
+    } else {
+      const t = (el.textContent ?? '').trim();
+      if (t) lines.push({ text: t, group });
+    }
+  }
+
+  for (let i = 0; i < lines.length - 1; i++) {
+    const head = lines[i];
+    const tail = lines[i + 1];
+    if (head.group !== tail.group) continue;
+    // One or more trailing hyphens: mermaid appends its own even when the token
+    // already ends in one, which is how "controller-tools" becomes "controller--".
+    if (!/[A-Za-z0-9]-+$/.test(head.text)) continue;
+
+    if (source.includes(squash(head.text + tail.text))) continue; // author's hyphen
+    if (source.includes(squash(head.text.slice(0, -1) + tail.text))) return true;
+  }
+
+  return false;
+}
+
+/**
+ * Render through the presets widest-first, discarding any that corrupt a token,
+ * and keep the widest survivor that fits the column. When none fit, the
+ * narrowest survivor is the largest the text can be drawn without breaking it.
+ * Only if every preset corrupts something do we fall back to the narrowest
+ * render, which is still better than showing nothing.
+ */
+export async function pickLayout(
+  columnWidth: number,
+  chart: string,
+  renderWith: (layoutIndex: number) => Promise<string>
+): Promise<string | null> {
+  let narrowestClean: string | null = null;
+  let narrowestAny: string | null = null;
+
+  for (let i = 0; i < LAYOUTS.length; i++) {
+    let svg: string;
+    try {
+      svg = await renderWith(i);
+    } catch {
+      continue; // a preset that mermaid rejects is not a reason to give up
+    }
+    narrowestAny = svg;
+
+    if (hasInventedHyphen(svg, chart)) continue;
+
+    const width = intrinsicWidthOf(svg);
+    if (width === null) return svg; // cannot measure it, so take it as-is
+    if (fitsColumn(width, columnWidth)) return svg;
+    narrowestClean = svg;
+  }
+
+  return narrowestClean ?? narrowestAny;
+}
+
+/** Diagnostic: which presets a chart can use, and what each one costs. */
+export async function explainLayouts(
+  chart: string,
+  renderWith: (layoutIndex: number) => Promise<string>
+): Promise<Array<{ name: string; width: number | null; clean: boolean }>> {
+  const rows = [];
+  for (let i = 0; i < LAYOUTS.length; i++) {
+    try {
+      const svg = await renderWith(i);
+      rows.push({
+        name: LAYOUTS[i].name,
+        width: intrinsicWidthOf(svg),
+        clean: !hasInventedHyphen(svg, chart),
+      });
+    } catch {
+      rows.push({ name: LAYOUTS[i].name, width: null, clean: false });
+    }
+  }
+  return rows;
+}
+
+/** Serialises every mermaid render in the page.
+ *
+ *  mermaid's sequence renderer keeps its options in a module-level `conf` that
+ *  draw() reassigns on entry and then reads again after a dozen awaits, right
+ *  down to the viewBox computation. Two renders in flight at once therefore lay
+ *  out against each other's spacing, and the width we measure gets attributed to
+ *  the wrong preset. That is not hypothetical here: the preset ladder is the
+ *  whole mechanism, and two diagrams on one page would be enough. Queueing costs
+ *  nothing, since a render is a few milliseconds and happens once per resize. */
+let renderQueue: Promise<unknown> = Promise.resolve();
+
+function serialized<T>(task: () => Promise<T>): Promise<T> {
+  const run = renderQueue.then(task, task);
+  // Keep the chain alive even when a preset throws, so one bad render cannot
+  // wedge every diagram that comes after it.
+  renderQueue = run.then(
+    () => undefined,
+    () => undefined
+  );
+  return run;
+}
+
 export default function Mermaid({ chart }: MermaidProps) {
   const containerRef = useRef<HTMLDivElement>(null);
   const [svg, setSvg] = useState<string>('');
   const [error, setError] = useState<string | null>(null);
+  // Column width the current SVG was chosen for, so resizes that cannot change
+  // the outcome do not trigger a re-render.
+  const renderedForRef = useRef<number>(-1);
 
   useEffect(() => {
-    const renderChart = async () => {
-      if (!containerRef.current) return;
+    let cancelled = false;
+    let frame = 0;
+    const container = containerRef.current;
+    if (!container) return;
 
+    const renderChart = async (columnWidth: number) => {
+      // Claim the width before the first await. The ResizeObserver fires as soon
+      // as the SVG changes the container's height, which is well before an async
+      // render finishes, and without this claim that fire sees no recorded width
+      // and starts the whole preset ladder a second time.
+      renderedForRef.current = columnWidth;
       try {
         const mermaid = (await import('mermaid')).default;
 
@@ -69,29 +272,72 @@ export default function Mermaid({ chart }: MermaidProps) {
           errorTextColor: getCSSVar('--mermaid-primary-text'),
         };
 
-        mermaid.initialize({
-          startOnLoad: false,
-          theme: 'base',
-          themeVariables,
-          securityLevel: 'loose',
-          fontFamily: 'inherit',
-          // Keep the SVG at its intrinsic width so the wrapper's overflow-x-auto
-          // can scroll it. Without this, mermaid emits width="100%" and the
-          // diagram silently shrinks to the prose column instead of scrolling.
-          sequence: { useMaxWidth: false },
-        });
+        const seed = Math.random().toString(36).slice(2, 11);
 
-        const id = `mermaid-${Math.random().toString(36).substr(2, 9)}`;
-        const { svg } = await mermaid.render(id, chart);
-        setSvg(svg);
+        const renderPreset = (i: number, id: string) =>
+          serialized(async () => {
+            mermaid.initialize({
+              startOnLoad: false,
+              theme: 'base',
+              themeVariables,
+              securityLevel: 'loose',
+              fontFamily: 'inherit',
+              // useMaxWidth lets the SVG scale down into its column instead of
+              // overflowing it. The presets are what keep that scaling legible.
+              sequence: { useMaxWidth: true, ...LAYOUTS[i].sequence },
+              flowchart: { useMaxWidth: true },
+            });
+            const { svg: out } = await mermaid.render(id, chart);
+            return out;
+          });
+
+        const next = await pickLayout(columnWidth, chart, (i) =>
+          renderPreset(i, `mermaid-${seed}-${i}`)
+        );
+
+        if (cancelled) return;
+        if (next === null) {
+          setError('Failed to render diagram');
+          return;
+        }
+        if (typeof window !== 'undefined' && window.location.search.includes('diagramDebug')) {
+          console.log(
+            'mermaid layouts',
+            columnWidth,
+            JSON.stringify(await explainLayouts(chart, (i) => renderPreset(i, `dbg-${seed}-${i}`)))
+          );
+        }
+        renderedForRef.current = columnWidth;
+        setSvg(next);
         setError(null);
       } catch (err) {
         console.error('Mermaid rendering error:', err);
-        setError('Failed to render diagram');
+        if (!cancelled) setError('Failed to render diagram');
       }
     };
 
-    renderChart();
+    void renderChart(container.clientWidth);
+
+    // Re-pick the preset when the column changes width enough to matter, so
+    // rotating a phone or resizing a window lands on the right one.
+    const observer = new ResizeObserver(() => {
+      cancelAnimationFrame(frame);
+      frame = requestAnimationFrame(() => {
+        const width = container.clientWidth;
+        if (width <= 0) return;
+        const last = renderedForRef.current;
+        // A resize can only change the outcome if it crosses a preset boundary.
+        if (last > 0 && Math.abs(width - last) / last < 0.02) return;
+        void renderChart(width);
+      });
+    });
+    observer.observe(container);
+
+    return () => {
+      cancelled = true;
+      cancelAnimationFrame(frame);
+      observer.disconnect();
+    };
   }, [chart]);
 
   if (error) {
@@ -105,7 +351,7 @@ export default function Mermaid({ chart }: MermaidProps) {
   return (
     <div
       ref={containerRef}
-      className="mermaid-diagram my-6 overflow-x-auto"
+      className="mermaid-diagram my-6"
       dangerouslySetInnerHTML={{ __html: svg }}
     />
   );

--- a/src/components/mdx/SessionBridge.tsx
+++ b/src/components/mdx/SessionBridge.tsx
@@ -1,48 +1,29 @@
 /*
- * SessionBridge — Static SVG showing how planning files bridge ephemeral sessions.
+ * SessionBridge — how planning files bridge ephemeral sessions.
  *
- * Visual language matches ContextFlow: same column styling, same color tokens,
- * same typography. Session columns are ephemeral (dashed border), bridge is
- * persistent (solid accent border).
+ * Built from HTML and CSS rather than a fixed-viewBox SVG, matching
+ * RollingUpdateVisualizer and TimelineCompare. The SVG version scaled a
+ * 720-unit-wide drawing into the prose column, which multiplied its 9px and
+ * 12px labels by 0.42 on a phone and rendered them at 4px. Text here is in rem
+ * and never scales with the container, so it reads at every width, and it also
+ * responds to a reader who enlarges their browser font, which viewBox units
+ * cannot do.
  */
 
-const VB_W = 720;
-const VB_H = 260;
+interface Session {
+  name: string;
+  sub: string;
+  items: string[];
+}
 
-/* ── Layout ──────────────────────────────────── */
-
-const COL_W = 160;
-const BRIDGE_W = 120;
-const GAP = 36;
-const TOTAL_W = COL_W * 2 + BRIDGE_W + GAP * 2;
-const X0 = (VB_W - TOTAL_W) / 2;
-const COL_Y = 10;
-const COL_H = 220;
-const RX = 14;
-
-const BRIDGE_X = X0 + COL_W + GAP;
-const BRIDGE_Y = COL_Y + 20;
-const BRIDGE_H = COL_H - 40;
-
-/* ── Colors — same tokens as ContextFlow ────── */
-
-const FILL_BG = '#f5f5f7';
-const STROKE_SOFT = '#d2d2d7';
-const TEXT_PRIMARY = '#1d1d1f';
-const TEXT_SECONDARY = '#86868b';
-const ACCENT = '#0071e3';
-const ACCENT_FILL = '#e8f0fe';
-
-/* ── Data ────────────────────────────────────── */
-
-const COLS = [
+const SESSIONS: [Session, Session] = [
   {
-    label: 'Session N',
+    name: 'Session N',
     sub: 'Execute phase 3',
     items: ['Read STATE.md', 'Run plan tasks', 'Distill SUMMARY.md'],
   },
   {
-    label: 'Session N+1',
+    name: 'Session N+1',
     sub: 'Execute phase 4',
     items: ['Read SUMMARY.md', 'Load decisions', 'Continue from state'],
   },
@@ -50,12 +31,33 @@ const COLS = [
 
 const FILES = ['STATE.md', 'PLAN.md', 'SUMMARY.md', 'CONTEXT.md'];
 
-/* ── Component ───────────────────────────────── */
+function SessionCard({ session }: { session: Session }) {
+  return (
+    <div className="sb-session">
+      <span className="sb-session-name">{session.name}</span>
+      <span className="sb-session-sub">{session.sub}</span>
+      <ul className="sb-tasks">
+        {session.items.map((item) => (
+          <li key={item} className="sb-task">
+            {item}
+          </li>
+        ))}
+      </ul>
+      <span className="sb-tag">ephemeral</span>
+    </div>
+  );
+}
+
+function Arrow({ label }: { label: string }) {
+  return (
+    <div className="sb-arrow">
+      <span className="sb-arrow-label">{label}</span>
+      <span className="sb-arrow-line" aria-hidden="true" />
+    </div>
+  );
+}
 
 export default function SessionBridge() {
-  const s1x = X0;
-  const s2x = X0 + COL_W + GAP + BRIDGE_W + GAP;
-
   return (
     <figure
       className="sb not-prose"
@@ -64,266 +66,32 @@ export default function SessionBridge() {
     >
       <div className="sb-header">
         <span className="sb-title">Session Handoff</span>
-        <span className="sb-subtitle">Planning files persist across ephemeral sessions</span>
+        <span className="sb-subtitle">
+          Planning files persist across ephemeral sessions
+        </span>
       </div>
-      <svg
-        className="sb-svg"
-        viewBox={`0 0 ${VB_W} ${VB_H}`}
-        preserveAspectRatio="xMidYMid meet"
-      >
-        {/* ── Session columns (ephemeral) ── */}
-        {COLS.map((col, cIdx) => {
-          const sx = cIdx === 0 ? s1x : s2x;
-          return (
-            <g key={`col-${cIdx}`}>
-              <rect
-                x={sx}
-                y={COL_Y}
-                width={COL_W}
-                height={COL_H}
-                rx={RX}
-                ry={RX}
-                fill={FILL_BG}
-                stroke={STROKE_SOFT}
-                strokeWidth={1}
-              />
 
-              {/* Label */}
-              <text
-                x={sx + COL_W / 2}
-                y={COL_Y + 24}
-                textAnchor="middle"
-                fill={TEXT_PRIMARY}
-                style={{
-                  fontFamily: 'var(--font-heading), system-ui, sans-serif',
-                  fontSize: '12px',
-                  fontWeight: 600,
-                  letterSpacing: '-0.01em',
-                }}
-              >
-                {col.label}
-              </text>
+      {/* DOM order reads left to right on desktop and top to bottom on a phone,
+          so the stacked layout needs no reordering. */}
+      <div className="sb-body">
+        <SessionCard session={SESSIONS[0]} />
+        <Arrow label="distill" />
 
-              {/* Subtitle */}
-              <text
-                x={sx + COL_W / 2}
-                y={COL_Y + 40}
-                textAnchor="middle"
-                fill={TEXT_SECONDARY}
-                style={{
-                  fontFamily: 'var(--font-mono), ui-monospace, monospace',
-                  fontSize: '9.5px',
-                  fontWeight: 400,
-                }}
-              >
-                {col.sub}
-              </text>
-
-              {/* Task items */}
-              {col.items.map((item, iIdx) => {
-                const iy = COL_Y + 56 + iIdx * 38;
-                return (
-                  <g key={`item-${cIdx}-${iIdx}`}>
-                    <rect
-                      x={sx + 10}
-                      y={iy}
-                      width={COL_W - 20}
-                      height={28}
-                      rx={6}
-                      ry={6}
-                      fill={ACCENT_FILL}
-                      stroke={ACCENT}
-                      strokeWidth={0.75}
-                      strokeOpacity={0.4}
-                    />
-                    <text
-                      x={sx + COL_W / 2}
-                      y={iy + 18}
-                      textAnchor="middle"
-                      fill={ACCENT}
-                      style={{
-                        fontFamily:
-                          'var(--font-heading), system-ui, sans-serif',
-                        fontSize: '9.5px',
-                        fontWeight: 500,
-                      }}
-                    >
-                      {item}
-                    </text>
-                  </g>
-                );
-              })}
-
-              {/* Ephemeral tag */}
-              <text
-                x={sx + COL_W / 2}
-                y={COL_Y + COL_H - 10}
-                textAnchor="middle"
-                fill={TEXT_SECONDARY}
-                style={{
-                  fontFamily: 'var(--font-heading), system-ui, sans-serif',
-                  fontSize: '9px',
-                  fontWeight: 400,
-                }}
-              >
-                ephemeral
-              </text>
-            </g>
-          );
-        })}
-
-        {/* ── Central bridge (persistent) ── */}
-        <rect
-          x={BRIDGE_X}
-          y={BRIDGE_Y}
-          width={BRIDGE_W}
-          height={BRIDGE_H}
-          rx={RX}
-          ry={RX}
-          fill={ACCENT_FILL}
-          stroke={ACCENT}
-          strokeWidth={1.25}
-        />
-
-        {/* Bridge header */}
-        <text
-          x={BRIDGE_X + BRIDGE_W / 2}
-          y={BRIDGE_Y + 22}
-          textAnchor="middle"
-          fill={ACCENT}
-          style={{
-            fontFamily: 'var(--font-mono), ui-monospace, monospace',
-            fontSize: '11px',
-            fontWeight: 600,
-          }}
-        >
-          .planning/
-        </text>
-
-        {/* Divider */}
-        <line
-          x1={BRIDGE_X + 12}
-          y1={BRIDGE_Y + 32}
-          x2={BRIDGE_X + BRIDGE_W - 12}
-          y2={BRIDGE_Y + 32}
-          stroke={ACCENT}
-          strokeWidth={0.5}
-          strokeOpacity={0.2}
-        />
-
-        {/* File entries */}
-        {FILES.map((file, fIdx) => {
-          const fy = BRIDGE_Y + 44 + fIdx * 28;
-          return (
-            <g key={`file-${fIdx}`}>
-              <rect
-                x={BRIDGE_X + 10}
-                y={fy}
-                width={BRIDGE_W - 20}
-                height={20}
-                rx={6}
-                ry={6}
-                fill="white"
-                stroke={ACCENT}
-                strokeWidth={0.5}
-                strokeOpacity={0.3}
-              />
-              <text
-                x={BRIDGE_X + BRIDGE_W / 2}
-                y={fy + 14}
-                textAnchor="middle"
-                fill={ACCENT}
-                style={{
-                  fontFamily: 'var(--font-mono), ui-monospace, monospace',
-                  fontSize: '9px',
-                  fontWeight: 500,
-                }}
-              >
+        <div className="sb-bridge">
+          <span className="sb-bridge-head">.planning/</span>
+          <ul className="sb-files">
+            {FILES.map((file) => (
+              <li key={file} className="sb-file">
                 {file}
-              </text>
-            </g>
-          );
-        })}
+              </li>
+            ))}
+          </ul>
+          <span className="sb-tag sb-tag-persistent">persistent</span>
+        </div>
 
-        {/* Persistent tag */}
-        <text
-          x={BRIDGE_X + BRIDGE_W / 2}
-          y={BRIDGE_Y + BRIDGE_H - 8}
-          textAnchor="middle"
-          fill={ACCENT}
-          style={{
-            fontFamily: 'var(--font-heading), system-ui, sans-serif',
-            fontSize: '9px',
-            fontWeight: 500,
-          }}
-        >
-          persistent
-        </text>
-
-        {/* ── Arrows ── */}
-        <defs>
-          <marker
-            id="sb-arrow"
-            markerWidth={7}
-            markerHeight={5}
-            refX={6}
-            refY={2.5}
-            orient="auto"
-          >
-            <path d="M 0 0 L 7 2.5 L 0 5 Z" fill={ACCENT} fillOpacity={0.6} />
-          </marker>
-        </defs>
-
-        {/* Write: Session N → Bridge */}
-        <line
-          x1={s1x + COL_W + 2}
-          y1={COL_Y + COL_H / 2 - 8}
-          x2={BRIDGE_X - 2}
-          y2={COL_Y + COL_H / 2 - 8}
-          stroke={ACCENT}
-          strokeWidth={1}
-          strokeOpacity={0.5}
-          markerEnd="url(#sb-arrow)"
-        />
-        <text
-          x={s1x + COL_W + GAP / 2}
-          y={COL_Y + COL_H / 2 - 16}
-          textAnchor="middle"
-          fill={ACCENT}
-          style={{
-            fontFamily: 'var(--font-heading), system-ui, sans-serif',
-            fontSize: '9px',
-            fontWeight: 500,
-          }}
-        >
-          distill
-        </text>
-
-        {/* Read: Bridge → Session N+1 */}
-        <line
-          x1={BRIDGE_X + BRIDGE_W + 2}
-          y1={COL_Y + COL_H / 2 - 8}
-          x2={s2x - 2}
-          y2={COL_Y + COL_H / 2 - 8}
-          stroke={ACCENT}
-          strokeWidth={1}
-          strokeOpacity={0.5}
-          markerEnd="url(#sb-arrow)"
-        />
-        <text
-          x={BRIDGE_X + BRIDGE_W + GAP / 2}
-          y={COL_Y + COL_H / 2 - 16}
-          textAnchor="middle"
-          fill={ACCENT}
-          style={{
-            fontFamily: 'var(--font-heading), system-ui, sans-serif',
-            fontSize: '9px',
-            fontWeight: 500,
-          }}
-        >
-          read
-        </text>
-      </svg>
+        <Arrow label="read" />
+        <SessionCard session={SESSIONS[1]} />
+      </div>
     </figure>
   );
 }

--- a/src/content/archive/markdown.mdx
+++ b/src/content/archive/markdown.mdx
@@ -137,10 +137,10 @@ Underscores
 ```mermaid
 sequenceDiagram
     autonumber
-    participant LB as Load Balancer (Probe)
-    participant A1 as App (Instance 1)
-    participant KERN as Host Kernel
-    participant A2 as App (Instance 2)
+    participant LB as Load Balancer
+    participant A1 as App 1
+    participant KERN as Kernel
+    participant A2 as App 2
 
     Note over A1: Phase 1: The Race
     A1->>KERN: Bind TCP :4190
@@ -154,13 +154,13 @@ sequenceDiagram
 
     Note over KERN: Phase 2: The Phantom Lock
     KERN->>KERN: Socket -> TIME_WAIT / FIN-WAIT-2
-    Note right of KERN: Kernel holds port 4190<br/>to protect data integrity
+    Note right of KERN: Kernel holds port 4190<br/>to protect<br/>data integrity
 
     Note over A2: Phase 3: The Restart
     LB->>A2: Kubelet restarts Pod
     A2->>KERN: Bind TCP :4190
     KERN-->>A2: ❌ FAIL: Address in use
-    Note left of KERN: Blocked by Instance 1's<br/>ghost in Kernel memory
+    Note left of KERN: Blocked by App 1's<br/>ghost in<br/>kernel memory
 ```
 
 ## (Sub,Super)script


### PR DESCRIPTION
Diagrams no longer scroll sideways on a phone, and no longer break out of the prose column.

## Summary

The mermaid diagram on [the-maximum-became-the-minimum](https://www.waynewen.com/blog/the-maximum-became-the-minimum) was unusable on mobile: at a 390px viewport it rendered 1191px of diagram into a 326px column, hiding 73% behind a horizontal scroll. #56 chose that deliberately, to escape the opposite failure where scaling to fit produced 5.5px text. Both ends are unusable, because the diagram is 3.7× the width of the phone column — no sizing strategy alone can fix it.

This shrinks the diagram at the source. `Mermaid.tsx` renders through a ladder of layout presets that tighten spacing and cap wrap width, and keeps the widest one that fits the column.

It also constrains diagrams to the prose column. Mermaid was the only element on the page that did not line up: at 1440px paragraphs, `pre`, `table`, `.rv`, `.tc` and `.sb` are all 640px, and mermaid was 1200px.

## Details

**Never corrupt a label to make it fit.** A preset is discarded if it made mermaid invent a hyphen inside a token. Without that check, the fix silently rendered `9223372036854775807` as `9223372036854-775807` — in a post whose entire subject is that exact integer. An invented hyphen is distinguished from one the author wrote by rejoining the split and asking which form the chart actually contains, so `controller-` / `tools` still wraps normally.

**SessionBridge was worse and silent.** It fit its column, so it never registered as an overflow, but a fixed `720`-unit viewBox scaled into that column multiplied its 9px labels by 0.42: **4px text at 320px, 10px even on desktop**. Raising the source font sizes cannot help — `src / viewBox` is invariant under scaling. Rebuilt as HTML + CSS like `RollingUpdateVisualizer` and `TimelineCompare`, so type is in `rem`, never scales, and responds to a reader who enlarges their browser font. It now uses the shared tokens instead of hardcoded Apple hexes, and its ephemeral cards are dashed — which its own file header claimed, but its code did not do.

**Two defects found by review, not by symptom:**

- Every diagram ran its **entire preset ladder twice** on mount. The `ResizeObserver` fires as soon as the new SVG changes the container height, well before the async render records a width, so the guard saw nothing recorded and started over.
- mermaid's sequence renderer keeps its options in a module-level `conf` that `draw()` reassigns on entry and re-reads after a dozen `await`s, down to the viewBox computation. Two overlapping renders lay out against each other's spacing, so a measured width gets attributed to the wrong preset. Renders are now serialised.

## Verification

Measured with headless Chrome against a production build, 9 pages × 7 viewports from 320px to 1440px:

| check | result |
| --- | --- |
| horizontal scroll | 0 |
| diagram width ≠ paragraph width | 0 |
| corrupted tokens | 0 |
| page-level overflow | 0 |
| tests | 117 pass (30 new) |

Smallest on-screen label per diagram:

| diagram | @320 | @390 | @768+ |
| --- | --- | --- | --- |
| SessionBridge | 12px | 12px | 12px |
| one-second-29-days | 14px | 19px | 20px |
| archive/markdown | 9px | 11px | 20px |
| the-maximum-became-the-minimum | 6px | 8px | 15px |

The maximum post's floor is structural rather than a defect: a 19-digit literal needs ~190px of wrap width, and four lifelines of it come to 896px — the narrowest the diagram can be without corrupting the number. It stays faithful and scales to fit; pinch-zoom covers the rest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
